### PR TITLE
Add Library / Installable Package project type flavor

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ You can also jump directly to any workflow with slash commands, or let the skill
 | `references/data-ml.md` | Same for data science and ML projects |
 | `references/devops.md` | Same for DevOps and infrastructure |
 | `references/fullstack.md` | Same for full-stack projects (also loads frontend + backend refs) |
+| `references/library.md` | Same for library / installable package projects (composable with domain flavors) |
 | `commands/` | Ten Claude Code slash commands for each workflow + status check |
 | `examples/` | Complete PDD example for a Task Management API |
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -34,7 +34,8 @@ This skill turns Claude into a PDD partner — helping users structure, operate,
 
 1. **Check `pdd/context/project.md`** if it exists — look at the tech stack section
 2. **Infer from what the user says** — framework names, tools, or domain language
-3. **If still unclear**, ask: *"What kind of project is this — web frontend, backend API, mobile app, data/ML pipeline, infrastructure, or full-stack?"*
+3. **Check if it's a library** — look for signals like `exports` map in package.json, `lib/` output dir, `prepublishOnly` script, `pyproject.toml` with build system, `Cargo.toml` with `[lib]`, or user mentions "package", "library", "crate", "module", "SDK". If so, load `references/library.md` alongside any domain flavor.
+4. **If still unclear**, ask: *"What kind of project is this — web frontend, backend API, mobile app, data/ML pipeline, infrastructure, or full-stack? And is this a library/package consumed by other developers, or a production application?"*
 
 ### Project type → reference file
 
@@ -46,13 +47,16 @@ This skill turns Claude into a PDD partner — helping users structure, operate,
 | Data / ML / AI | Python, Jupyter, pandas, PyTorch, scikit-learn, pipelines | `references/data-ml.md` |
 | DevOps / Infra | Terraform, Docker, Kubernetes, CI/CD, AWS, GCP, Azure | `references/devops.md` |
 | Full-stack | Frontend + backend together, Next.js, Nuxt, SvelteKit | `references/fullstack.md` + `references/frontend.md` + `references/backend.md` |
-| Other / Unrecognized | Embedded, game dev, firmware, desktop, or anything not above | No reference file — use base workflows only |
+| Library / Package | npm package, PyPI library, crate, gem, Go module, SDK, reusable component lib | `references/library.md` (+ domain flavor if applicable) |
+| Other / Unrecognized | Embedded, game dev, firmware, desktop, or anything not above | No reference file ��� use base workflows only |
 
 Once the type is identified, read the corresponding reference file and use it to enrich: context file questions and templates, conventions starter content, prompt patterns, and the review checklist.
 
 If the project spans multiple types, load all relevant reference files. When conventions conflict, ask the user which to follow and capture the decision in `pdd/context/decisions.md`.
 
 **Full-stack merge priority**: When `fullstack.md`, `frontend.md`, and `backend.md` are loaded together, `fullstack.md` conventions take precedence where they overlap (e.g., naming, project structure, API design). Fall through to the frontend or backend reference only for concerns fullstack.md doesn't address.
+
+**Library is composable**: A project can be both a library and a domain type (e.g., a React component library = `library.md` + `frontend.md`). When combined, `library.md` takes precedence for API surface, versioning, and distribution concerns; the domain flavor takes precedence for implementation patterns.
 
 ---
 

--- a/copilot/README.md
+++ b/copilot/README.md
@@ -40,6 +40,7 @@ Your project should end up with:
     data-ml.md
     devops.md
     fullstack.md
+    library.md
 ```
 
 ## Usage

--- a/copilot/copilot-instructions.md
+++ b/copilot/copilot-instructions.md
@@ -18,6 +18,7 @@ Before helping with PDD workflows, detect the project type to tailor your guidan
 | Data / ML / AI | Python, Jupyter, pandas, PyTorch, pipelines |
 | DevOps / Infra | Terraform, Docker, Kubernetes, CI/CD, cloud providers |
 | Full-stack | Frontend + backend together, Next.js, Nuxt, SvelteKit |
+| Library / Package | npm package, PyPI library, crate, gem, Go module, SDK, "publish", `exports` map |
 
 ## Core Principles
 

--- a/docs/philosophy.md
+++ b/docs/philosophy.md
@@ -114,7 +114,7 @@ The core PDD structure is universal — it works for any kind of project. But wh
 graph TD
     PDD((PDD Core))
 
-    PDD --> row1[ ] & row2[ ]
+    PDD --> row1[ ] & row2[ ] & row3[ ]
 
     row1 --> FE["Frontend / UI"]
     row1 --> BE["Backend / API"]
@@ -124,8 +124,11 @@ graph TD
     row2 --> DO["DevOps / Infra"]
     row2 --> FS["Full-stack"]
 
+    row3 --> LB["Library / Package"]
+
     style row1 fill:none,stroke:none
     style row2 fill:none,stroke:none
+    style row3 fill:none,stroke:none
     style PDD fill:#2c3e50,stroke:#1a252f,color:#fff
     style FE fill:#3498db,stroke:#2471a3,color:#fff
     style BE fill:#9b59b6,stroke:#7d3c98,color:#fff
@@ -133,9 +136,11 @@ graph TD
     style DA fill:#27ae60,stroke:#1e8449,color:#fff
     style DO fill:#e74c3c,stroke:#c0392b,color:#fff
     style FS fill:#1abc9c,stroke:#17a589,color:#fff
+    style LB fill:#f39c12,stroke:#d68910,color:#fff
 
     linkStyle 0 stroke:none
     linkStyle 1 stroke:none
+    linkStyle 2 stroke:none
 ```
 
 | Flavor | Key concerns |
@@ -146,8 +151,9 @@ graph TD
 | **Data / ML** | Dataset provenance, model selection, eval metrics, pipeline idempotency |
 | **DevOps / Infra** | IaC conventions, blast radius, secret management, change safety |
 | **Full-stack** | Client/server boundary, shared types, API contracts |
+| **Library / Package** | Public API design, semver, dependency policy, tree-shaking, multi-environment support |
 
-A React app and a Python data pipeline both need a `project.md` and versioned prompts. What changes is what goes inside them.
+A React app and a Python data pipeline both need a `project.md` and versioned prompts. What changes is what goes inside them. The Library flavor is **composable** — a React component library would combine it with the Frontend flavor, a Python ML toolkit with the Data / ML flavor.
 
 ---
 

--- a/references/library.md
+++ b/references/library.md
@@ -1,0 +1,213 @@
+# PDD Reference: Library / Installable Package Projects
+
+> **Last reviewed**: 2026-03
+
+Use this file to enrich Workflows 2, 3, and 5 for library and package projects (npm modules, PyPI packages, Rust crates, Go modules, Ruby gems, and similar distributable code).
+
+**This flavor is composable** — a project can be both a library and another type (e.g., a React component library uses this + `frontend.md`). When combining, this file's constraints take precedence for API surface, versioning, and distribution concerns; the domain flavor takes precedence for implementation patterns.
+
+---
+
+## Additional Context Questions (Workflow 2)
+
+Ask these after the base questions in `project.md`:
+
+- What package ecosystem? (npm, PyPI, crates.io, Go modules, Maven, RubyGems, NuGet)
+- What language and minimum runtime version do you support?
+- Module formats needed? (ESM, CJS, dual, UMD)
+- Does it need to work in multiple environments? (Node, browser, Deno, edge runtimes)
+- TypeScript / type strategy? (source in TS, generated `.d.ts`, hand-written stubs)
+- Who is the target audience? (other library authors, app developers, beginners)
+- Monorepo or single package?
+- Current versioning stage? (0.x experimental, 1.x stable, pre-release)
+- What's your dependency philosophy? (zero-dep, minimal, batteries-included)
+- Does it wrap or extend another library? (plugin, adapter, wrapper)
+
+### Extended `pdd/context/project.md` sections for libraries
+
+```markdown
+## Public API
+- Exported modules / entry points:
+- Design principles: (minimal surface, progressive disclosure, etc.)
+- Naming conventions for public APIs:
+
+## Distribution
+- Package ecosystem:
+- Module formats: (ESM / CJS / dual / UMD)
+- Supported environments: (Node >= X, browsers, Deno, edge)
+- Bundle size budget:
+
+## Versioning
+- Current version:
+- Versioning policy: (semver — what counts as breaking)
+- Deprecation strategy:
+
+## Types
+- TypeScript strategy: (source in TS / generated .d.ts / hand-written stubs)
+- Type test tool: (tsd, dtslint, expect-type, none)
+
+## Dependencies
+- Policy: (zero-dep / minimal / batteries-included)
+- Peer dependencies:
+- Maximum acceptable install size:
+```
+
+---
+
+## Conventions Starter (Workflow 2)
+
+```markdown
+# Library Conventions
+
+## Public API
+- Every export is a contract — don't export internal helpers
+- Prefer named exports over default exports (better tree-shaking, clearer imports)
+- Group related exports in subpath entry points (e.g. `my-lib/utils`, `my-lib/types`)
+- No side effects on import — importing the package must not execute code or modify globals
+
+## Naming
+- Public functions / classes: camelCase / PascalCase matching ecosystem convention
+- Internal helpers: prefixed with underscore or in unexported modules
+- File names: match the primary export (e.g. `createClient.ts` exports `createClient`)
+
+## Versioning
+- Follow semver strictly
+- Breaking changes: removing/renaming exports, changing return types, adding required params
+- Non-breaking: adding optional params, new exports, bug fixes, performance improvements
+- Document every breaking change in CHANGELOG.md with migration instructions
+
+## Dependencies
+- Justify every dependency — what it provides vs. its install size and maintenance risk
+- Prefer peer dependencies for anything the consumer likely already has
+- Never import from a dependency's internal paths (e.g. `lodash/internal/foo`)
+
+## Error handling
+- Throw typed errors that consumers can catch programmatically
+- Include error codes or classes — not just message strings
+- Document all error types in the API reference
+
+## Testing
+- Test the public API, not internal implementation details
+- Test across supported runtime versions in CI
+- Test both ESM and CJS imports if shipping dual format
+- Include integration tests that simulate real consumer usage
+```
+
+---
+
+## Common Feature Prompt Patterns (Workflow 3)
+
+### New public API function
+
+```markdown
+# Prompt: <functionName>
+
+## Task
+Create a public API function `<functionName>` that <does what>.
+
+## Signature
+- Parameters: <name: type — description, for each>
+- Returns: <type — description>
+- Throws: <error type — when>
+
+## Behavior
+- <core behavior>
+- <edge cases: empty input, null, invalid types>
+
+## Constraints
+- Zero side effects — must be a pure function (or clearly documented if not)
+- No new dependencies
+- Must work in [Node / browser / both — match project scope]
+- Export from <entry point>
+- Include JSDoc / docstring with @param, @returns, @throws, @example
+
+## Output format
+- Implementation file
+- Type definitions (if separate from source)
+- Unit tests covering happy path, edge cases, and error cases
+- No test file scaffolding — full passing tests
+```
+
+### Breaking change / major version update
+
+```markdown
+# Prompt: Migrate <old API> to <new API>
+
+## Task
+Replace `<old function/type/export>` with `<new version>` in a backward-incompatible way.
+
+## Changes
+- <what changes and why>
+
+## Migration path
+- Provide a CHANGELOG entry describing the break
+- Provide a migration guide: before/after code examples
+- If feasible, provide a codemod or deprecation warning in the current minor version first
+
+## Constraints
+- Update all internal usages
+- Update type definitions
+- Update tests to use new API
+- Remove old API completely (no re-export shims)
+```
+
+### New subpath entry point
+
+```markdown
+# Prompt: Add <subpath> entry point
+
+## Task
+Create a new subpath export at `<package-name>/<subpath>` that exposes <what>.
+
+## Exports
+- <named exports this entry point provides>
+
+## Constraints
+- Update package.json `exports` map
+- Ensure tree-shaking works — no shared side-effect modules between entry points
+- Add TypeScript types for the subpath
+- Test that `import { x } from '<package>/<subpath>'` works in both ESM and CJS
+- Document the new entry point in README
+```
+
+---
+
+## Review Checklist (Workflow 5)
+
+Apply in addition to the universal review dimensions:
+
+**API surface**
+- [ ] Only intended symbols exported? No internal helpers leaking?
+- [ ] Naming consistent with existing public API?
+- [ ] Backward compatible with current major version? (if not, is this intentional?)
+- [ ] JSDoc / docstring present on all public exports?
+- [ ] No required parameters added to existing functions?
+
+**Distribution**
+- [ ] Package loads correctly via ESM import?
+- [ ] Package loads correctly via CJS require? (if dual format)
+- [ ] `exports` map in package.json is correct and complete?
+- [ ] Type definitions accurate and tested?
+- [ ] No side effects on import?
+- [ ] Tree-shaking works — unused exports eliminated by bundlers?
+
+**Dependencies**
+- [ ] No new dependencies without justification?
+- [ ] No imports from dependency internal paths?
+- [ ] Peer dependencies declared correctly?
+- [ ] Total install size within budget?
+
+**Compatibility**
+- [ ] Works across all supported environments (Node versions, browsers)?
+- [ ] No environment-specific globals without feature detection (e.g., `window`, `process`)?
+- [ ] No Node built-in imports in browser-targeted code?
+
+**Versioning**
+- [ ] Version bump matches change type (patch/minor/major)?
+- [ ] CHANGELOG updated?
+- [ ] Breaking changes documented with migration guide?
+
+**Consumer experience**
+- [ ] Error messages actionable — include what went wrong and how to fix it?
+- [ ] TypeScript autocomplete works correctly for the new API?
+- [ ] README / API docs updated for new or changed exports?


### PR DESCRIPTION
## Summary

- Add `references/library.md` — full reference file with context questions, conventions starter, prompt patterns, and review checklist for library/package projects
- Add Library to project type detection in SKILL.md with auto-detection signals (exports map, `[lib]` in Cargo.toml, etc.)
- Add composability note — Library stacks on top of domain flavors (e.g., React component lib = library + frontend)
- Update philosophy.md diagram and flavor table
- Update both READMEs and copilot-instructions.md

## Test plan

- [x] All reference files exist (`references/*.md`)
- [x] Copilot README lists all reference files including `library.md`
- [x] Commands and Copilot prompts are in sync (`diff` shows no divergence)
- [x] Pre-PR checklist from CLAUDE.md passes clean

Closes #15