### PR TITLE
Add pdd-help command for workflow discovery and quick reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Then invoke them in Claude Code:
 | `/project:pdd-review` | Verify and review AI-generated output before committing |
 | `/project:pdd-eval` | Run prompt evaluations and track pass rates over time |
 | `/project:pdd-status` | Health check — shows what's set up, what's missing, and what's stale |
+| `/project:pdd-help` | Quick reference — lists all commands, workflow order, and usage guidance |
 
 All commands accept optional arguments, e.g., `/project:pdd-scaffold my-api` or `/project:pdd-review paste your code here`.
 
@@ -145,7 +146,7 @@ You can also jump directly to any workflow with slash commands, or let the skill
 | `references/desktop-gui.md` | Same for desktop / native GUI projects (window management, OS integration, code signing, auto-updates, cross-platform) |
 | `references/compiler-lang.md` | Same for compiler / language tooling projects (parsing, AST design, type systems, error recovery, LSP integration) |
 | `references/robotics.md` | Same for robotics / ROS projects (real-time control, sensor fusion, simulation-first, safety systems, coordinate frames) |
-| `commands/` | Ten Claude Code slash commands for each workflow + status check |
+| `commands/` | Eleven Claude Code slash commands for each workflow + status check + help |
 | `examples/` | Complete PDD example for a Task Management API |
 
 The skill auto-detects your project type and loads the right reference file to enrich context questions, conventions, and review checklists.

--- a/SKILL.md
+++ b/SKILL.md
@@ -83,6 +83,7 @@ If the project spans multiple types, load all relevant reference files. When con
 | "This prompt isn't working", "Can you improve this prompt?" | → **Update** |
 | "Check this code", "Run the quality checks", "Is this ready to commit?", "Review this output", pastes code without instructions | → **Review** |
 | "How is my prompt performing?", "Run the eval", "Track prompt quality" | → **Eval** |
+| "What commands are there?", "Help me with PDD", "What can you do?", "How does PDD work?" | → **Help**: run `/project:pdd-help` |
 | Vague or unclear | → Ask: *"Are you starting a new project, working on a feature prompt, or reviewing something the AI generated?"* |
 
 **If context files don't exist yet:** Don't block the user. Proceed with the requested workflow and suggest context files afterward.

--- a/commands/pdd-help.md
+++ b/commands/pdd-help.md
@@ -1,0 +1,85 @@
+# PDD Help
+
+Quick reference for all PDD commands, workflow order, and usage guidance.
+
+**User input**: $ARGUMENTS
+
+## If the user passed an argument
+
+If `$ARGUMENTS` names a specific command (e.g., "context", "pdd-context", "review"), show detailed help for that command only:
+
+- **What it does** — one-paragraph description
+- **When to use it** — the situation that calls for this workflow
+- **Inputs it expects** — what the user should provide or have ready
+- **What it produces** — the output artifact(s)
+- **Typical next step** — what command usually follows
+
+Use the command table and routing guide below to compose the answer. Give the user just what they asked about — don't dump the full help.
+
+## If no argument was provided
+
+Show the full quick reference below.
+
+---
+
+### Quick start
+
+> **Quick start**: For most features, you only need three commands: **Context → Prompts → Review**. Add Search, Plan, and Eval for complex or critical features.
+
+### All commands
+
+**Getting started**
+
+| Command | What it does |
+|---|---|
+| `/project:pdd-help` | Show this quick reference |
+| `/project:pdd-scaffold` | Set up a new PDD project with folders, context stubs, and git init |
+| `/project:pdd-init` | Add PDD to an existing project — auto-detects stack and conventions |
+| `/project:pdd-status` | Health check — shows what's set up, what's missing, and what's stale |
+
+**Building features**
+
+| Command | What it does |
+|---|---|
+| `/project:pdd-context` | Write or update context files (project.md, conventions.md, decisions.md) |
+| `/project:pdd-search` | Research existing solutions before building custom |
+| `/project:pdd-plan` | Decompose a feature into phases and prompt chain strategy |
+| `/project:pdd-prompts` | Generate well-structured feature prompts |
+| `/project:pdd-update` | Improve or refactor an existing prompt |
+
+**Quality**
+
+| Command | What it does |
+|---|---|
+| `/project:pdd-review` | Verify AI-generated output before committing |
+| `/project:pdd-eval` | Run prompt evaluations and track quality over time |
+
+### "What should I use?"
+
+| I want to... | Use |
+|---|---|
+| Start a brand new project | `pdd-scaffold` → `pdd-context` |
+| Add PDD to an existing codebase | `pdd-init` → `pdd-context` |
+| Build a new feature (complex) | `pdd-context` → `pdd-search` → `pdd-plan` → `pdd-prompts` → `pdd-review` |
+| Build a new feature (simple) | `pdd-context` → `pdd-prompts` → `pdd-review` |
+| Fix a prompt that isn't working | `pdd-update` |
+| Check if my project setup is complete | `pdd-status` |
+| Track prompt quality over time | `pdd-eval` |
+
+### Per-command detail
+
+Use this table when the user asks about a specific command.
+
+| Command | When to use | Inputs | Produces | Next step |
+|---|---|---|---|---|
+| `pdd-scaffold` | Starting a brand new project from scratch | Project name (optional) | Folder structure with context stubs | `pdd-context` |
+| `pdd-init` | Adding PDD to a project that already has code | Existing project directory | PDD folders + auto-detected context | `pdd-context` |
+| `pdd-context` | Before writing prompts, or when the project changes | Answers to context questions | `pdd/context/project.md`, `conventions.md`, `decisions.md` | `pdd-search` or `pdd-prompts` |
+| `pdd-search` | Before building something that might already exist | Feature description | Summary of existing solutions + build/buy recommendation | `pdd-plan` or `pdd-prompts` |
+| `pdd-plan` | Feature spans multiple files, modules, or phases | Feature description + context files | Phased implementation plan with prompt chain strategy | `pdd-prompts` |
+| `pdd-prompts` | Ready to write the actual feature prompt | Feature description + context files | Prompt file(s) in `pdd/prompts/features/` | Run the prompt, then `pdd-review` |
+| `pdd-update` | A prompt isn't producing good results | The failing prompt + what went wrong | Updated prompt file | Run the prompt again, then `pdd-review` |
+| `pdd-review` | AI generated code and you want to verify it | Generated code (pasted or in files) | Quality report + fix suggestions | Commit or iterate |
+| `pdd-eval` | After committing, to track prompt reliability | Prompt file + expected outcomes | Eval results in `pdd/evals/` | Update prompt if quality drops |
+| `pdd-status` | Want to check project health | None | Status report with suggestions | Whatever the report recommends |
+| `pdd-help` | Want to see available commands | Command name (optional) | This reference | Whatever workflow fits |

--- a/copilot/README.md
+++ b/copilot/README.md
@@ -33,6 +33,7 @@ Your project should end up with:
     pdd-review.prompt.md
     pdd-eval.prompt.md
     pdd-status.prompt.md
+    pdd-help.prompt.md
   references/
     frontend.md
     backend.md
@@ -68,6 +69,7 @@ In VS Code Copilot Chat, type `/` to see available prompt files, then select one
 | `/pdd-review` | Verify and review AI-generated code before committing |
 | `/pdd-eval` | Run prompt evaluations and track pass rates |
 | `/pdd-status` | Health check — what's set up, what's missing, what's stale |
+| `/pdd-help` | Quick reference — lists all commands, workflow order, and usage guidance |
 
 The `copilot-instructions.md` file loads automatically in every Copilot Chat session, providing PDD-aware routing and core principles.
 

--- a/copilot/copilot-instructions.md
+++ b/copilot/copilot-instructions.md
@@ -52,3 +52,4 @@ Before helping with PDD workflows, detect the project type to tailor your guidan
 | Review AI-generated code (includes quality checks) | Use `/pdd-review` |
 | Track prompt quality and pass rates | Use `/pdd-eval` |
 | Check project PDD health | Use `/pdd-status` |
+| List available commands / how PDD works / get help | Use `/pdd-help` |

--- a/copilot/prompts/pdd-help.prompt.md
+++ b/copilot/prompts/pdd-help.prompt.md
@@ -1,0 +1,88 @@
+---
+agent: agent
+description: "Quick reference for all PDD commands, workflow order, and usage guidance"
+---
+
+# PDD Help
+
+Quick reference for all PDD commands, workflow order, and usage guidance.
+
+## If the user asked about a specific command
+
+If the user mentioned a specific command (e.g., "context", "pdd-context", "review"), show detailed help for that command only:
+
+- **What it does** — one-paragraph description
+- **When to use it** — the situation that calls for this workflow
+- **Inputs it expects** — what the user should provide or have ready
+- **What it produces** — the output artifact(s)
+- **Typical next step** — what command usually follows
+
+Use the command table and routing guide below to compose the answer. Give the user just what they asked about — don't dump the full help.
+
+## If no specific command was mentioned
+
+Show the full quick reference below.
+
+---
+
+### Quick start
+
+> **Quick start**: For most features, you only need three commands: **Context → Prompts → Review**. Add Search, Plan, and Eval for complex or critical features.
+
+### All commands
+
+**Getting started**
+
+| Command | What it does |
+|---|---|
+| `/pdd-help` | Show this quick reference |
+| `/pdd-scaffold` | Set up a new PDD project with folders, context stubs, and git init |
+| `/pdd-init` | Add PDD to an existing project — auto-detects stack and conventions |
+| `/pdd-status` | Health check — shows what's set up, what's missing, and what's stale |
+
+**Building features**
+
+| Command | What it does |
+|---|---|
+| `/pdd-context` | Write or update context files (project.md, conventions.md, decisions.md) |
+| `/pdd-search` | Research existing solutions before building custom |
+| `/pdd-plan` | Decompose a feature into phases and prompt chain strategy |
+| `/pdd-prompts` | Generate well-structured feature prompts |
+| `/pdd-update` | Improve or refactor an existing prompt |
+
+**Quality**
+
+| Command | What it does |
+|---|---|
+| `/pdd-review` | Verify AI-generated output before committing |
+| `/pdd-eval` | Run prompt evaluations and track quality over time |
+
+### "What should I use?"
+
+| I want to... | Use |
+|---|---|
+| Start a brand new project | `/pdd-scaffold` → `/pdd-context` |
+| Add PDD to an existing codebase | `/pdd-init` → `/pdd-context` |
+| Build a new feature (complex) | `/pdd-context` → `/pdd-search` → `/pdd-plan` → `/pdd-prompts` → `/pdd-review` |
+| Build a new feature (simple) | `/pdd-context` → `/pdd-prompts` → `/pdd-review` |
+| Fix a prompt that isn't working | `/pdd-update` |
+| Check if my project setup is complete | `/pdd-status` |
+| Track prompt quality over time | `/pdd-eval` |
+
+### Per-command detail
+
+Use this table when the user asks about a specific command.
+
+| Command | When to use | Inputs | Produces | Next step |
+|---|---|---|---|---|
+| `pdd-scaffold` | Starting a brand new project from scratch | Project name (optional) | Folder structure with context stubs | `/pdd-context` |
+| `pdd-init` | Adding PDD to a project that already has code | Existing project directory | PDD folders + auto-detected context | `/pdd-context` |
+| `pdd-context` | Before writing prompts, or when the project changes | Answers to context questions | `pdd/context/project.md`, `conventions.md`, `decisions.md` | `/pdd-search` or `/pdd-prompts` |
+| `pdd-search` | Before building something that might already exist | Feature description | Summary of existing solutions + build/buy recommendation | `/pdd-plan` or `/pdd-prompts` |
+| `pdd-plan` | Feature spans multiple files, modules, or phases | Feature description + context files | Phased implementation plan with prompt chain strategy | `/pdd-prompts` |
+| `pdd-prompts` | Ready to write the actual feature prompt | Feature description + context files | Prompt file(s) in `pdd/prompts/features/` | Run the prompt, then `/pdd-review` |
+| `pdd-update` | A prompt isn't producing good results | The failing prompt + what went wrong | Updated prompt file | Run the prompt again, then `/pdd-review` |
+| `pdd-review` | AI generated code and you want to verify it | Generated code (pasted or in files) | Quality report + fix suggestions | Commit or iterate |
+| `pdd-eval` | After committing, to track prompt reliability | Prompt file + expected outcomes | Eval results in `pdd/evals/` | Update prompt if quality drops |
+| `pdd-status` | Want to check project health | None | Status report with suggestions | Whatever the report recommends |
+| `pdd-help` | Want to see available commands | Command name (optional) | This reference | Whatever workflow fits |


### PR DESCRIPTION
## Summary

- Adds a `pdd-help` utility command that lists all PDD commands, shows workflow order, routing guidance, and per-command detail when given an argument
- Updates all cross-file references (SKILL.md routing, both READMEs, copilot-instructions.md)

Closes #28

## Test plan

- [ ] Run `/project:pdd-help` — should display grouped command table, routing guide, and quick start
- [ ] Run `/project:pdd-help context` — should show detail for pdd-context only (what it does, inputs, outputs, next step)
- [ ] Run `/pdd-help` in Copilot Chat — should display equivalent output with `/pdd-*` references
- [ ] Verify `diff <(ls commands/ | sed 's/.md//' | sort) <(ls copilot/prompts/ | sed 's/.prompt.md//' | sort)` produces no output
- [ ] Verify command count in README.md says "Eleven"
- [ ] Verify SKILL.md Step 0 routes "What can you do?" to Help