### PR TITLE
Add CI gate for cross-file consistency checks

### DIFF
--- a/.github/workflows/consistency.yml
+++ b/.github/workflows/consistency.yml
@@ -1,0 +1,12 @@
+name: Consistency
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: bash tests/consistency.sh

--- a/tests/consistency.sh
+++ b/tests/consistency.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FAIL=0
+fail() { echo "FAIL: $1"; FAIL=1; }
+pass() { echo "OK:   $1"; }
+
+# ── 1. Commands ↔ Copilot prompts parity ──
+diff_output=$(diff \
+  <(ls commands/ | sed 's/.md//' | sort) \
+  <(ls copilot/prompts/ | sed 's/.prompt.md//' | sort) || true)
+
+if [ -n "$diff_output" ]; then
+  fail "commands/ and copilot/prompts/ are out of sync:"
+  echo "$diff_output"
+else
+  pass "commands/ ↔ copilot/prompts/ in sync"
+fi
+
+# ── 2. Reference files exist ──
+for f in frontend backend mobile data-ml devops fullstack; do
+  [ -f "references/$f.md" ] && pass "references/$f.md" || fail "references/$f.md missing"
+done
+
+# ── 3. Copilot README covers all references ──
+for f in frontend backend mobile data-ml devops fullstack; do
+  grep -q "$f.md" copilot/README.md \
+    && pass "$f.md in copilot/README.md" \
+    || fail "$f.md missing from copilot/README.md setup"
+done
+
+# ── 4. Slash command refs in commands/ resolve ──
+grep -roh '/project:pdd-[a-z-]*' commands/*.md 2>/dev/null | sort -u | while read -r cmd; do
+  target="commands/$(echo "$cmd" | sed 's|/project:||').md"
+  [ -f "$target" ] && pass "$cmd → $target" || fail "$cmd → $target not found"
+done
+
+# ── 5. Every command file in README ──
+for f in $(ls commands/ | sed 's/.md//'); do
+  grep -q "$f" README.md \
+    && pass "$f in README.md" \
+    || fail "$f missing from README.md"
+done
+
+# ── 6. Every copilot prompt in copilot README ──
+for f in $(ls copilot/prompts/ | sed 's/.prompt.md//'); do
+  grep -q "$f" copilot/README.md \
+    && pass "$f in copilot/README.md" \
+    || fail "$f missing from copilot/README.md"
+done
+
+# ── 7. Workflow count sanity ──
+skill_count=$(grep -c '^## Workflow' SKILL.md)
+cmd_count=$(ls commands/pdd-*.md | wc -l | tr -d ' ')
+# commands include help + status, so cmd_count = skill_count + 2
+expected=$((skill_count + 2))
+if [ "$cmd_count" -eq "$expected" ]; then
+  pass "Workflow count: $skill_count workflows, $cmd_count commands (includes help+status)"
+else
+  fail "Workflow count mismatch: SKILL.md has $skill_count, commands/ has $cmd_count (expected $expected)"
+fi
+
+echo ""
+if [ "$FAIL" -eq 0 ]; then
+  echo "All checks passed."
+  exit 0
+else
+  echo "Some checks failed."
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- Adds `tests/consistency.sh` — a single shell script that automates the manual pre-PR checks from CLAUDE.md
- Adds `.github/workflows/consistency.yml` — runs the script on every PR to `main`

### Checks covered (44 total)

| Check | What it catches |
|---|---|
| Commands ↔ Copilot parity | New command without matching copilot prompt (or vice versa) |
| Reference files exist | Deleted or renamed `references/*.md` |
| Copilot README covers refs | Missing setup instructions for a reference file |
| Slash command refs resolve | `/project:pdd-foo` pointing to a non-existent command |
| README tables complete | Command missing from the README command table |
| Workflow count sanity | SKILL.md workflow count vs actual file count drift |

No dependencies — pure bash, runs in under a second.

Closes #30

## Test plan

- [x] `bash tests/consistency.sh` passes locally (all 44 checks OK)
- [ ] GitHub Actions workflow runs on this PR