### PR TITLE
Fix Mermaid diagram rendering on GitHub Pages

### DIFF
--- a/docs/_includes/head-custom.html
+++ b/docs/_includes/head-custom.html
@@ -1,0 +1,14 @@
+<script type="module">
+  import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
+
+  // Jekyll renders ```mermaid as <pre><code class="language-mermaid">
+  // Convert to <div class="mermaid"> for Mermaid.js
+  document.querySelectorAll('pre code.language-mermaid').forEach((block) => {
+    const div = document.createElement('div');
+    div.className = 'mermaid';
+    div.textContent = block.textContent;
+    block.parentElement.replaceWith(div);
+  });
+
+  mermaid.initialize({ startOnLoad: true, theme: 'neutral' });
+</script>


### PR DESCRIPTION
## Summary

- Adds `docs/_includes/head-custom.html` that loads Mermaid.js from CDN
- Converts Jekyll's `<pre><code class="language-mermaid">` blocks to `<div class="mermaid">` at page load
- Uses the minimal theme's `head-custom.html` hook — no layout override needed

Single file, ~10 lines of JS. All 6 Mermaid diagrams in the philosophy page should now render.

## Test plan

- [x] `bash tests/consistency.sh` passes
- [ ] Pages deployment succeeds
- [ ] Mermaid diagrams render on `harshal2802.github.io/pdd-skill/philosophy`