### PR TITLE
Switch to Cayman theme and add LinkedIn profile

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -5,7 +5,7 @@ description: >-
 url: "https://harshal2802.github.io"
 baseurl: "/pdd-skill"
 
-remote_theme: pages-themes/minimal@v0.2.0
+remote_theme: pages-themes/cayman@v0.2.0
 
 plugins:
   - jekyll-seo-tag
@@ -17,9 +17,10 @@ author: Harshal
 twitter:
   card: summary_large_image
 social:
-  name: Harshal
+  name: Harshal Chourasiya
   links:
     - https://github.com/harshal2802
+    - https://www.linkedin.com/in/harshal-chourasiya-39bb0426
 
 defaults:
   - scope:

--- a/docs/index.md
+++ b/docs/index.md
@@ -47,3 +47,7 @@ echo '{ "skills": [".claude/skills/pdd-skill/SKILL.md"] }' > .claude/settings.js
 - **[The Philosophy Behind PDD](philosophy)** — Why structure matters, the four layers, project type flavors, and how to get started
 - **[GitHub Repository](https://github.com/harshal2802/pdd-skill)** — Source code, installation instructions, and examples
 - **[Copilot Version](https://github.com/harshal2802/pdd-skill/tree/main/copilot)** — Same workflows adapted for GitHub Copilot Chat
+
+---
+
+Built by [Harshal Chourasiya](https://www.linkedin.com/in/harshal-chourasiya-39bb0426) · [GitHub](https://github.com/harshal2802)


### PR DESCRIPTION
## Summary

- Switches Jekyll theme from minimal to Cayman
- Adds LinkedIn profile to SEO social links (Open Graph / structured data)
- Adds author footer with LinkedIn + GitHub links on landing page

## Test plan

- [x] `bash tests/consistency.sh` passes
- [x] Pages deployment succeeds
- [x] Cayman theme renders correctly
- [x] Mermaid diagrams still work with new theme
- [x] LinkedIn link works in footer