### PR TITLE
Add all 16 project types to pdd-context and pdd-init detection tables

### DIFF
--- a/commands/pdd-context.md
+++ b/commands/pdd-context.md
@@ -11,11 +11,21 @@ Check `pdd/context/project.md` (if it exists) or infer from user input. Load the
 | Type | Signals | Reference |
 |---|---|---|
 | Frontend / UI | React, Vue, Angular, Svelte, CSS, Tailwind | `references/frontend.md` |
-| Backend / API | Node, FastAPI, Django, Rails, REST, GraphQL | `references/backend.md` |
-| Mobile | iOS, Android, Swift, Kotlin, React Native, Flutter | `references/mobile.md` |
-| Data / ML / AI | Python, Jupyter, pandas, PyTorch, pipelines | `references/data-ml.md` |
-| DevOps / Infra | Terraform, Docker, Kubernetes, CI/CD, AWS | `references/devops.md` |
-| Full-stack | Frontend + backend, Next.js, Nuxt, SvelteKit | `references/fullstack.md` |
+| Backend / API | Node, FastAPI, Django, Rails, REST, GraphQL, gRPC, databases | `references/backend.md` |
+| Mobile | iOS, Android, Swift, Kotlin, React Native, Flutter, Expo | `references/mobile.md` |
+| Data / ML / AI | Python, Jupyter, pandas, PyTorch, scikit-learn, pipelines | `references/data-ml.md` |
+| DevOps / Infra | Terraform, Docker, Kubernetes, CI/CD, AWS, GCP, Azure | `references/devops.md` |
+| Full-stack | Frontend + backend, Next.js, Nuxt, SvelteKit | `references/fullstack.md` + `references/frontend.md` + `references/backend.md` |
+| Library / Package | npm package, PyPI library, crate, gem, Go module, SDK | `references/library.md` (+ domain flavor if applicable) |
+| CLI / Developer Tools | CLI app, terminal tool, code generator, REPL, arg parsing, subcommands | `references/cli-devtools.md` |
+| Embedded / IoT | MCU, RTOS, bare-metal, Arduino, ESP32, STM32, Zephyr, FreeRTOS, firmware | `references/embedded-iot.md` |
+| Game Development | Unity, Unreal, Godot, Bevy, game engine, ECS, frame budget | `references/game-dev.md` |
+| Blockchain / Smart Contracts | Solidity, Vyper, Rust/Anchor, Hardhat, Foundry, EVM, Solana, DeFi | `references/blockchain.md` |
+| Security / Pentesting Tools | Scanner, fuzzer, exploit framework, SIEM, detection rules, pentest | `references/security.md` |
+| API Platform / SDK | Public API, developer platform, OpenAPI, SDK generation, rate limiting, webhooks | `references/api-platform.md` |
+| Desktop / Native GUI | Tauri, Electron, Flutter desktop, SwiftUI macOS, Qt, .NET MAUI, WPF | `references/desktop-gui.md` |
+| Compiler / Language Tooling | Compiler, interpreter, transpiler, linter, formatter, LSP server, parser, AST | `references/compiler-lang.md` |
+| Robotics / ROS | ROS, ROS2, robot, drone, autonomous vehicle, URDF, Gazebo, MoveIt, Nav2 | `references/robotics.md` |
 
 ## If creating new context files
 

--- a/commands/pdd-init.md
+++ b/commands/pdd-init.md
@@ -20,6 +20,16 @@ You are adding Prompt Driven Development structure to an existing project that a
 | `requirements.txt` with pandas/torch/scikit-learn, `setup.py` with ML deps, Jupyter notebooks | Data / ML |
 | `Dockerfile`, `terraform/`, `k8s/`, `.github/workflows/`, `Pulumi.yaml` | DevOps |
 | `next.config.*`, `nuxt.config.*`, `svelte.config.*`, or frontend + backend signals together | Full-stack |
+| `exports` map in `package.json`, `[lib]` in `Cargo.toml`, `pyproject.toml` with build system, `prepublishOnly` script | Library / Package |
+| CLI entry point (`bin` in `package.json`), `clap`/`cobra`/`yargs`/`argparse` deps, subcommand patterns | CLI / Developer Tools |
+| Arduino/PlatformIO configs, `CMakeLists.txt` with MCU targets, Zephyr/FreeRTOS deps, `.ino` files | Embedded / IoT |
+| Unity `ProjectSettings/`, Unreal `.uproject`, Godot `project.godot`, Bevy in `Cargo.toml` deps | Game Development |
+| `hardhat.config.*`, `foundry.toml`, Solidity `.sol` files, Anchor `programs/`, Move `.move` files | Blockchain / Smart Contracts |
+| Security tool configs, nuclei templates, Burp extensions, detection rules, YARA/Sigma files | Security / Pentesting Tools |
+| OpenAPI/Swagger specs, SDK generation configs (Stainless, Fern), API versioning patterns | API Platform / SDK |
+| `tauri.conf.json`, Electron `main.js`/`preload.js`, Qt `.pro`/`CMakeLists.txt`, `.NET MAUI` configs | Desktop / Native GUI |
+| Parser generators (tree-sitter, ANTLR), AST definitions, LSP server configs, LLVM/Cranelift deps | Compiler / Language Tooling |
+| ROS `package.xml`, `CMakeLists.txt` with `ament_cmake`/`catkin`, URDF/XACRO files, launch files | Robotics / ROS |
 
 If multiple types match, mention all and ask the user to confirm the primary type.
 

--- a/copilot/prompts/pdd-context.prompt.md
+++ b/copilot/prompts/pdd-context.prompt.md
@@ -14,11 +14,21 @@ Check `pdd/context/project.md` (if it exists) or infer from the user's language.
 | Type | Signals | Reference |
 |---|---|---|
 | Frontend / UI | React, Vue, Angular, Svelte, CSS, Tailwind | `#file:references/frontend.md` |
-| Backend / API | Node, FastAPI, Django, Rails, REST, GraphQL | `#file:references/backend.md` |
-| Mobile | iOS, Android, Swift, Kotlin, React Native, Flutter | `#file:references/mobile.md` |
-| Data / ML / AI | Python, Jupyter, pandas, PyTorch, pipelines | `#file:references/data-ml.md` |
-| DevOps / Infra | Terraform, Docker, Kubernetes, CI/CD, AWS | `#file:references/devops.md` |
-| Full-stack | Frontend + backend, Next.js, Nuxt, SvelteKit | `#file:references/fullstack.md` |
+| Backend / API | Node, FastAPI, Django, Rails, REST, GraphQL, gRPC, databases | `#file:references/backend.md` |
+| Mobile | iOS, Android, Swift, Kotlin, React Native, Flutter, Expo | `#file:references/mobile.md` |
+| Data / ML / AI | Python, Jupyter, pandas, PyTorch, scikit-learn, pipelines | `#file:references/data-ml.md` |
+| DevOps / Infra | Terraform, Docker, Kubernetes, CI/CD, AWS, GCP, Azure | `#file:references/devops.md` |
+| Full-stack | Frontend + backend, Next.js, Nuxt, SvelteKit | `#file:references/fullstack.md` + `#file:references/frontend.md` + `#file:references/backend.md` |
+| Library / Package | npm package, PyPI library, crate, gem, Go module, SDK | `#file:references/library.md` (+ domain flavor if applicable) |
+| CLI / Developer Tools | CLI app, terminal tool, code generator, REPL, arg parsing, subcommands | `#file:references/cli-devtools.md` |
+| Embedded / IoT | MCU, RTOS, bare-metal, Arduino, ESP32, STM32, Zephyr, FreeRTOS, firmware | `#file:references/embedded-iot.md` |
+| Game Development | Unity, Unreal, Godot, Bevy, game engine, ECS, frame budget | `#file:references/game-dev.md` |
+| Blockchain / Smart Contracts | Solidity, Vyper, Rust/Anchor, Hardhat, Foundry, EVM, Solana, DeFi | `#file:references/blockchain.md` |
+| Security / Pentesting Tools | Scanner, fuzzer, exploit framework, SIEM, detection rules, pentest | `#file:references/security.md` |
+| API Platform / SDK | Public API, developer platform, OpenAPI, SDK generation, rate limiting, webhooks | `#file:references/api-platform.md` |
+| Desktop / Native GUI | Tauri, Electron, Flutter desktop, SwiftUI macOS, Qt, .NET MAUI, WPF | `#file:references/desktop-gui.md` |
+| Compiler / Language Tooling | Compiler, interpreter, transpiler, linter, formatter, LSP server, parser, AST | `#file:references/compiler-lang.md` |
+| Robotics / ROS | ROS, ROS2, robot, drone, autonomous vehicle, URDF, Gazebo, MoveIt, Nav2 | `#file:references/robotics.md` |
 
 ## If creating new context files
 

--- a/copilot/prompts/pdd-init.prompt.md
+++ b/copilot/prompts/pdd-init.prompt.md
@@ -23,6 +23,16 @@ You are adding Prompt Driven Development structure to an existing project that a
 | `requirements.txt` with pandas/torch/scikit-learn, `setup.py` with ML deps, Jupyter notebooks | Data / ML |
 | `Dockerfile`, `terraform/`, `k8s/`, `.github/workflows/`, `Pulumi.yaml` | DevOps |
 | `next.config.*`, `nuxt.config.*`, `svelte.config.*`, or frontend + backend signals together | Full-stack |
+| `exports` map in `package.json`, `[lib]` in `Cargo.toml`, `pyproject.toml` with build system, `prepublishOnly` script | Library / Package |
+| CLI entry point (`bin` in `package.json`), `clap`/`cobra`/`yargs`/`argparse` deps, subcommand patterns | CLI / Developer Tools |
+| Arduino/PlatformIO configs, `CMakeLists.txt` with MCU targets, Zephyr/FreeRTOS deps, `.ino` files | Embedded / IoT |
+| Unity `ProjectSettings/`, Unreal `.uproject`, Godot `project.godot`, Bevy in `Cargo.toml` deps | Game Development |
+| `hardhat.config.*`, `foundry.toml`, Solidity `.sol` files, Anchor `programs/`, Move `.move` files | Blockchain / Smart Contracts |
+| Security tool configs, nuclei templates, Burp extensions, detection rules, YARA/Sigma files | Security / Pentesting Tools |
+| OpenAPI/Swagger specs, SDK generation configs (Stainless, Fern), API versioning patterns | API Platform / SDK |
+| `tauri.conf.json`, Electron `main.js`/`preload.js`, Qt `.pro`/`CMakeLists.txt`, `.NET MAUI` configs | Desktop / Native GUI |
+| Parser generators (tree-sitter, ANTLR), AST definitions, LSP server configs, LLVM/Cranelift deps | Compiler / Language Tooling |
+| ROS `package.xml`, `CMakeLists.txt` with `ament_cmake`/`catkin`, URDF/XACRO files, launch files | Robotics / ROS |
 
 If multiple types match, mention all and ask the user to confirm.
 


### PR DESCRIPTION
## Summary
- Added the 10 missing project types to the type detection tables in `pdd-context` and `pdd-init` (both Claude Code commands and Copilot prompts)
- All 4 files now list all 16 types, matching `skills/pdd/SKILL.md`
- For `pdd-init`, added concrete auto-detection signals for each new type (file patterns, dependency markers, config files)

## Test plan
- [x] Verify all 16 types appear in `commands/pdd-context.md`
- [x] Verify all 16 types appear in `copilot/prompts/pdd-context.prompt.md` with `#file:` syntax
- [x] Verify all 16 types appear in `commands/pdd-init.md` with detection signals
- [x] Verify all 16 types appear in `copilot/prompts/pdd-init.prompt.md` with detection signals
- [x] Run `bash tests/consistency.sh` — all checks pass

Closes #42