### PR TITLE
Add marketplace.json for plugin discovery

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,31 @@
+{
+  "name": "pdd-skill",
+  "owner": {
+    "name": "harshal2802"
+  },
+  "metadata": {
+    "description": "Prompt Driven Development plugin marketplace"
+  },
+  "plugins": [
+    {
+      "name": "pdd-skill",
+      "source": ".",
+      "description": "Prompt Driven Development — structure AI-assisted projects with versioned prompts, persistent context, and automated review",
+      "version": "1.3.0",
+      "author": {
+        "name": "harshal2802"
+      },
+      "repository": "https://github.com/harshal2802/pdd-skill",
+      "homepage": "https://github.com/harshal2802/pdd-skill",
+      "license": "MIT",
+      "keywords": [
+        "pdd",
+        "prompt-driven-development",
+        "ai-assisted",
+        "prompts",
+        "code-review",
+        "scaffolding"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds `.claude-plugin/marketplace.json` so the repo can serve as a plugin marketplace
- Fixes: `/plugin marketplace add harshal2802/pdd-skill` was failing with "Marketplace file not found"

## Test plan
- [ ] Run `/plugin marketplace add harshal2802/pdd-skill` — should succeed
- [ ] Run `/plugin install pdd-skill` — should install the plugin
- [ ] Verify `claude plugin validate .` passes