### PR TITLE
Clarify scaffold src directory contract

### DIFF
--- a/core/workflows/scaffold.md
+++ b/core/workflows/scaffold.md
@@ -29,7 +29,7 @@ If the user already has a populated project directory or repository, route them 
 
 ## Step 2: Create The Base Structure
 
-Create a layout like:
+Create every folder and file shown in this layout. The source directory defaults to `src/` unless the user chose a different source directory name in Step 1.
 
 ```text
 <project-name>/
@@ -48,6 +48,15 @@ Create a layout like:
   <source-dir>/
   README.md
 ```
+
+On macOS/Linux, use commands like:
+
+```bash
+mkdir -p pdd/{prompts/{features,templates,experiments},context,evals/{baselines,scripts}} src
+touch pdd/context/project.md pdd/context/conventions.md pdd/context/decisions.md README.md
+```
+
+If the user chose a source directory name other than `src/`, replace `src` in the command with that name.
 
 Initialize git only if the directory is not already a repository.
 
@@ -73,7 +82,9 @@ Make it clear what each major folder is for:
 ## Produces
 
 - PDD folder structure under `pdd/`
+- source directory, defaulting to `src/`
 - starter context files
+- project `README.md`
 - a natural handoff to the context workflow
 
 ## Edge Cases

--- a/providers/claude/commands/pdd-scaffold.md
+++ b/providers/claude/commands/pdd-scaffold.md
@@ -33,7 +33,7 @@ If the user already has a populated project directory or repository, route them 
 
 ## Step 2: Create The Base Structure
 
-Create a layout like:
+Create every folder and file shown in this layout. The source directory defaults to `src/` unless the user chose a different source directory name in Step 1.
 
 ```text
 <project-name>/
@@ -52,6 +52,15 @@ Create a layout like:
   <source-dir>/
   README.md
 ```
+
+On macOS/Linux, use commands like:
+
+```bash
+mkdir -p pdd/{prompts/{features,templates,experiments},context,evals/{baselines,scripts}} src
+touch pdd/context/project.md pdd/context/conventions.md pdd/context/decisions.md README.md
+```
+
+If the user chose a source directory name other than `src/`, replace `src` in the command with that name.
 
 Initialize git only if the directory is not already a repository.
 
@@ -77,7 +86,9 @@ Make it clear what each major folder is for:
 ## Produces
 
 - PDD folder structure under `pdd/`
+- source directory, defaulting to `src/`
 - starter context files
+- project `README.md`
 - a natural handoff to the context workflow
 
 ## Edge Cases

--- a/providers/copilot/prompts/pdd-scaffold.prompt.md
+++ b/providers/copilot/prompts/pdd-scaffold.prompt.md
@@ -36,7 +36,7 @@ If the user already has a populated project directory or repository, route them 
 
 ## Step 2: Create The Base Structure
 
-Create a layout like:
+Create every folder and file shown in this layout. The source directory defaults to `src/` unless the user chose a different source directory name in Step 1.
 
 ```text
 <project-name>/
@@ -55,6 +55,15 @@ Create a layout like:
   <source-dir>/
   README.md
 ```
+
+On macOS/Linux, use commands like:
+
+```bash
+mkdir -p pdd/{prompts/{features,templates,experiments},context,evals/{baselines,scripts}} src
+touch pdd/context/project.md pdd/context/conventions.md pdd/context/decisions.md README.md
+```
+
+If the user chose a source directory name other than `src/`, replace `src` in the command with that name.
 
 Initialize git only if the directory is not already a repository.
 
@@ -80,7 +89,9 @@ Make it clear what each major folder is for:
 ## Produces
 
 - PDD folder structure under `pdd/`
+- source directory, defaulting to `src/`
 - starter context files
+- project `README.md`
 - a natural handoff to the context workflow
 
 ## Edge Cases

--- a/tests/test_metadata_model.py
+++ b/tests/test_metadata_model.py
@@ -223,6 +223,35 @@ def validate_generated_markers():
             )
 
 
+def validate_scaffold_contract():
+    expected_fragments = (
+        "The source directory defaults to `src/`",
+        "mkdir -p pdd/{prompts/{features,templates,experiments},context,evals/{baselines,scripts}} src",
+        "replace `src` in the command",
+        "- source directory, defaulting to `src/`",
+        "- project `README.md`",
+    )
+    scaffold_paths = (
+        ROOT / "core/workflows/scaffold.md",
+        ROOT / "providers/claude/commands/pdd-scaffold.md",
+        ROOT / "providers/copilot/prompts/pdd-scaffold.prompt.md",
+    )
+
+    for path in scaffold_paths:
+        text = path.read_text()
+        for fragment in expected_fragments:
+            assert_true(
+                fragment in text,
+                f"{path.relative_to(ROOT)} preserves scaffold source directory contract: {fragment}",
+            )
+
+    init_text = (ROOT / "core/workflows/init.md").read_text()
+    assert_true(
+        "Do not create a new source directory" in init_text,
+        "init workflow still avoids creating source directories",
+    )
+
+
 def main():
     workflows, workflow_ids, provider_ids = validate_workflows()
     validate_adapter_docs(workflows)
@@ -232,6 +261,7 @@ def main():
     validate_status()
     validate_claude_skill(workflows)
     validate_generated_markers()
+    validate_scaffold_contract()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Make the scaffold workflow explicitly create every folder and file in the layout, including `src/` by default.
- Regenerate the Claude and Copilot scaffold adapters from the shared workflow source.
- Add an executable regression check that the scaffold contract keeps the default source directory and README creation guidance, while init still avoids creating source directories.

Closes #77.

## Verification

- `python3 tests/test_metadata_model.py`
- `python3 scripts/render_workflow_tables.py --check --version v1.4.0`
- `bash tests/consistency.sh`
- `bash tests/test-hooks.sh`
