### PR TITLE
Add Google Antigravity as a fourth provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A multi-provider Prompt Driven Development toolkit for structuring AI-assisted development with versioned prompts, persistent context, and structured review.
 
-PDD treats prompts as first-class artifacts, not throwaway inputs. This repo currently packages the same core PDD system for Claude Code, GitHub Copilot, and Codex. The core workflows are **scaffold**, **init**, **context**, **research**, **plan**, **prompts**, **update**, **review**, **eval**, plus the `status` and `help` utility workflows.
+PDD treats prompts as first-class artifacts, not throwaway inputs. This repo currently packages the same core PDD system for Claude Code, GitHub Copilot, Codex, and Google Antigravity. The core workflows are **scaffold**, **init**, **context**, **research**, **plan**, **prompts**, **update**, **review**, **eval**, plus the `status` and `help` utility workflows.
 
 For simple features, you only need **Context → Prompts → Review**. Research, Plan, and Eval add value for complex or critical features but are not required.
 
@@ -15,6 +15,7 @@ PDD is packaged for three surfaces from the same shared core:
 | Claude Code | `providers/claude/` | Claude skill, slash commands, hooks, and plugin metadata |
 | GitHub Copilot | `providers/copilot/` | Copilot prompts plus always-on instructions |
 | Codex | `providers/codex/` | Codex plugin and `pdd` skill adapter |
+| Google Antigravity | `providers/antigravity/` | Antigravity skill, workflows, and `GEMINI.md` workspace rules |
 
 ### Claude Code
 
@@ -83,6 +84,33 @@ cp /tmp/pdd-skill/.agents/plugins/marketplace.json <your-project>/.agents/plugin
 The `pdd` skill exposes all workflows (e.g. `pdd:scaffold`, `pdd:context`, `pdd:review`).
 
 See [`providers/codex/README.md`](providers/codex/README.md) for layout details and the full command table.
+
+### Google Antigravity
+
+Clone the repo, then copy these files into your project:
+
+```bash
+git clone https://github.com/harshal2802/pdd-skill.git /tmp/pdd-skill
+
+# Copy the workspace rules
+cp /tmp/pdd-skill/providers/antigravity/GEMINI.md <your-project>/GEMINI.md
+
+# Copy the skill entrypoint
+mkdir -p <your-project>/.agents/skills/pdd
+cp /tmp/pdd-skill/providers/antigravity/skills/pdd/SKILL.md <your-project>/.agents/skills/pdd/SKILL.md
+
+# Copy the workflow files
+mkdir -p <your-project>/.agent/workflows
+cp /tmp/pdd-skill/providers/antigravity/workflows/*.md <your-project>/.agent/workflows/
+
+# Copy the reference files (project type flavors)
+mkdir -p <your-project>/.agent/references
+cp -r /tmp/pdd-skill/core/references/* <your-project>/.agent/references/
+```
+
+In Antigravity, the workflow files auto-expose as slash commands (e.g. `/pdd-scaffold`, `/pdd-context`). `GEMINI.md` is used instead of the cross-tool-standard `AGENTS.md` so installing alongside Codex or Cursor does not produce a rules-file collision.
+
+See [`providers/antigravity/README.md`](providers/antigravity/README.md) for layout details and the full command table.
 
 ## Repo Structure
 
@@ -172,6 +200,24 @@ Invoke them in Claude Code:
 <!-- GENERATED:claude-command-table:end -->
 
 All commands accept optional arguments, e.g., `/project:pdd-scaffold my-api` or `/project:pdd-review paste your code here`.
+
+In Antigravity (workflow files auto-expose as `/`-prefixed slash commands):
+
+<!-- GENERATED:antigravity-command-table:start -->
+| Command | What it does |
+|---|---|
+| `/pdd-scaffold` | Set up a new PDD project with folders, context stubs, and starter guidance. |
+| `/pdd-init` | Add PDD structure to an existing repository and infer a starting context. |
+| `/pdd-context` | Write or update the persistent project context files that future prompts depend on. |
+| `/pdd-research` | Explore the problem space, evaluate options, and decide what to build. |
+| `/pdd-plan` | Break a feature into phases and decide the prompt chain strategy before coding. |
+| `/pdd-prompts` | Generate focused feature prompts and place them in the right PDD folder. |
+| `/pdd-update` | Diagnose and improve a prompt that is producing weak or incorrect output. |
+| `/pdd-review` | Verify and review AI-generated output before it is committed. |
+| `/pdd-eval` | Track prompt quality over time with repeatable evaluation criteria. |
+| `/pdd-status` | Check what PDD artifacts exist, what is stale, and what to do next. |
+| `/pdd-help` | Show the available workflows, when to use them, and the typical sequence. |
+<!-- GENERATED:antigravity-command-table:end -->
 
 ## Workflow
 

--- a/core/metadata/principles.json
+++ b/core/metadata/principles.json
@@ -4,32 +4,38 @@
     {
       "claude": "**One prompt, one job.** Split if multiple concerns.",
       "copilot": "**One prompt, one job.** Split multi-concern tasks before prompting.",
-      "codex": "One prompt, one job."
+      "codex": "One prompt, one job.",
+      "antigravity": "**One prompt, one job.** Split if multiple concerns."
     },
     {
       "claude": "**Commit prompts alongside outputs.** The prompt is part of the codebase.",
       "copilot": "**Commit prompts alongside outputs.** The prompt is part of the codebase.",
-      "codex": "Commit prompts alongside outputs."
+      "codex": "Commit prompts alongside outputs.",
+      "antigravity": "**Commit prompts alongside outputs.** The prompt is part of the codebase."
     },
     {
       "claude": "**Update context after every significant decision.** Stale context degrades future prompts.",
       "copilot": "**Update context after every significant decision.** Stale context degrades future prompts.",
-      "codex": "Update context after meaningful decisions."
+      "codex": "Update context after meaningful decisions.",
+      "antigravity": "**Update context after every significant decision.** Stale context degrades future prompts."
     },
     {
       "claude": "**Timebox experiments.** Name with a date prefix (`YYYY-MM-DD-`). After one week: promote to `pdd/prompts/features/` if it worked, delete if it didn't.",
       "copilot": "**Timebox experiments.** Exploratory prompts go in `pdd/prompts/experiments/` with a date prefix (`YYYY-MM-DD-`). After one week: promote to `pdd/prompts/features/` or delete.",
-      "codex": "Timebox exploratory prompts."
+      "codex": "Timebox exploratory prompts.",
+      "antigravity": "**Timebox experiments.** Name with a date prefix (`YYYY-MM-DD-`). After one week: promote to `pdd/prompts/features/` if it worked, delete if it didn't."
     },
     {
       "claude": "**Never commit unreviewed output.** Treat it like a PR.",
       "copilot": "**Never commit unreviewed output.** Treat AI output like a PR.",
-      "codex": "Never commit unreviewed AI output."
+      "codex": "Never commit unreviewed AI output.",
+      "antigravity": "**Never commit unreviewed output.** Treat it like a PR."
     },
     {
       "claude": "**Context must reflect reality.** Aspirational `project.md` actively misleads.",
       "copilot": "**Context must reflect reality.** Aspirational project.md actively misleads.",
-      "codex": "Keep context truthful and current."
+      "codex": "Keep context truthful and current.",
+      "antigravity": "**Context must reflect reality.** Aspirational `project.md` actively misleads."
     }
   ],
   "codex_default_flow": {

--- a/core/metadata/providers.json
+++ b/core/metadata/providers.json
@@ -27,6 +27,16 @@
         ".agents/plugins/marketplace.json",
         "plugins/pdd-skill"
       ]
+    },
+    {
+      "id": "antigravity",
+      "label": "Google Antigravity",
+      "root": "providers/antigravity",
+      "compatibility_paths": [
+        "GEMINI.md",
+        "skills",
+        "workflows"
+      ]
     }
   ]
 }

--- a/core/metadata/routing.json
+++ b/core/metadata/routing.json
@@ -4,67 +4,78 @@
       "workflow_id": "scaffold",
       "claude_signal": "\"Start a new PDD project\", \"Set up folder structure\", \"How do I get started?\"",
       "copilot_intent": "Start a new project / set up structure",
-      "codex_intent": "Start a brand new PDD project"
+      "codex_intent": "Start a brand new PDD project",
+      "antigravity_intent": "Start a new project / set up structure"
     },
     {
       "workflow_id": "init",
       "claude_signal": "\"Add PDD to my project\", \"Initialize PDD here\", \"Set up PDD in this repo\"",
       "copilot_intent": "Add PDD to an existing project",
-      "codex_intent": "Add PDD to an existing repo"
+      "codex_intent": "Add PDD to an existing repo",
+      "antigravity_intent": "Add PDD to an existing project"
     },
     {
       "workflow_id": "context",
       "claude_signal": "\"Help me write my project.md\", \"What should my context file say?\"",
       "copilot_intent": "Write or update context files",
-      "codex_intent": "Write or refresh context files"
+      "codex_intent": "Write or refresh context files",
+      "antigravity_intent": "Write or update context files"
     },
     {
       "workflow_id": "research",
       "claude_signal": "\"Is there a library for this?\", \"Does something already do this?\", \"What should I build?\", \"Help me think through this\", \"I'm not sure what approach to take\"",
       "copilot_intent": "Explore a problem space, find existing solutions, evaluate approaches",
-      "codex_intent": "Explore the problem space first"
+      "codex_intent": "Explore the problem space first",
+      "antigravity_intent": "Explore a problem space, find existing solutions, evaluate approaches"
     },
     {
       "workflow_id": "plan",
       "claude_signal": "\"Plan this feature\", \"How should I break this down?\"",
       "copilot_intent": "Plan a feature before writing prompts",
-      "codex_intent": "Break work into phases before prompting"
+      "codex_intent": "Break work into phases before prompting",
+      "antigravity_intent": "Plan a feature before writing prompts"
     },
     {
       "workflow_id": "prompts",
       "claude_signal": "\"Write a prompt for this feature\", \"Help me prompt this\"",
       "copilot_intent": "Write a feature prompt",
-      "codex_intent": "Write a feature prompt"
+      "codex_intent": "Write a feature prompt",
+      "antigravity_intent": "Write a feature prompt"
     },
     {
       "workflow_id": "update",
       "claude_signal": "\"This prompt isn't working\", \"Can you improve this prompt?\"",
       "copilot_intent": "Fix a prompt that isn't working",
-      "codex_intent": "Fix a weak prompt"
+      "codex_intent": "Fix a weak prompt",
+      "antigravity_intent": "Fix a prompt that isn't working"
     },
     {
       "workflow_id": "review",
       "claude_signal": "\"Check this code\", \"Run the quality checks\", \"Is this ready to commit?\", \"Review this output\", pastes code without instructions",
       "copilot_intent": "Review AI-generated code (includes quality checks)",
-      "codex_intent": "Check generated output before commit"
+      "codex_intent": "Check generated output before commit",
+      "antigravity_intent": "Review AI-generated code (includes quality checks)"
     },
     {
       "workflow_id": "eval",
       "claude_signal": "\"How is my prompt performing?\", \"Run the eval\", \"Track prompt quality\"",
       "copilot_intent": "Track prompt quality and pass rates",
-      "codex_intent": "Measure prompt quality over time"
+      "codex_intent": "Measure prompt quality over time",
+      "antigravity_intent": "Track prompt quality and pass rates"
     },
     {
       "workflow_id": "status",
       "claude_signal": "\"What's set up?\", \"What's missing?\", \"Show me the project health\"",
       "copilot_intent": "Check project PDD health",
-      "codex_intent": "See what is set up or what is missing"
+      "codex_intent": "See what is set up or what is missing",
+      "antigravity_intent": "Check project PDD health"
     },
     {
       "workflow_id": "help",
       "claude_signal": "\"What commands are there?\", \"Help me with PDD\", \"What can you do?\", \"How does PDD work?\"",
       "copilot_intent": "List available commands / how PDD works / get help",
-      "codex_intent": "Get workflow guidance"
+      "codex_intent": "Get workflow guidance",
+      "antigravity_intent": "List available commands / how PDD works / get help"
     }
   ]
 }

--- a/core/metadata/status.json
+++ b/core/metadata/status.json
@@ -6,22 +6,26 @@
         {
           "check": "`pdd/context/project.md` exists and is non-empty",
           "claude_how": "Read file, check for filled-in sections",
-          "copilot_how": "Read file, check for filled-in sections"
+          "copilot_how": "Read file, check for filled-in sections",
+          "antigravity_how": "Read file, check for filled-in sections"
         },
         {
           "check": "`pdd/context/conventions.md` exists and is non-empty",
           "claude_how": "Read file",
-          "copilot_how": "Read file"
+          "copilot_how": "Read file",
+          "antigravity_how": "Read file"
         },
         {
           "check": "`pdd/context/decisions.md` exists and has entries",
           "claude_how": "Read file, count decisions",
-          "copilot_how": "Read file, count decisions"
+          "copilot_how": "Read file, count decisions",
+          "antigravity_how": "Read file, count decisions"
         },
         {
           "check": "Context is fresh",
           "claude_how": "Check for `**Last updated**` dates; flag if older than 30 days",
-          "copilot_how": "Check for `**Last updated**` dates; flag if older than 30 days"
+          "copilot_how": "Check for `**Last updated**` dates; flag if older than 30 days",
+          "antigravity_how": "Check for `**Last updated**` dates; flag if older than 30 days"
         }
       ]
     },
@@ -31,27 +35,32 @@
         {
           "check": "`pdd/prompts/features/` has prompt files",
           "claude_how": "Glob for `pdd/prompts/features/**/*.md`",
-          "copilot_how": "Look for `pdd/prompts/features/**/*.md`"
+          "copilot_how": "Look for `pdd/prompts/features/**/*.md`",
+          "antigravity_how": "Glob for `pdd/prompts/features/**/*.md`"
         },
         {
           "check": "Prompts follow the template structure",
           "claude_how": "Spot-check for `## Task`, `## Context`, `## Constraints` sections",
-          "copilot_how": "Spot-check for `## Task`, `## Context`, `## Constraints` sections"
+          "copilot_how": "Spot-check for `## Task`, `## Context`, `## Constraints` sections",
+          "antigravity_how": "Spot-check for `## Task`, `## Context`, `## Constraints` sections"
         },
         {
           "check": "`pdd/prompts/experiments/` has stale entries",
           "claude_how": "Flag any experiment files older than 7 days; suggest \"Promote to `pdd/prompts/features/` or delete\"",
-          "copilot_how": "Flag any experiment files older than 7 days; suggest \"Promote to `pdd/prompts/features/` or delete\""
+          "copilot_how": "Flag any experiment files older than 7 days; suggest \"Promote to `pdd/prompts/features/` or delete\"",
+          "antigravity_how": "Flag any experiment files older than 7 days; suggest \"Promote to `pdd/prompts/features/` or delete\""
         },
         {
           "check": "Prompt chains are complete",
           "claude_how": "Check numbered sequences for gaps (for example, `-01-` exists but `-02-` is missing)",
-          "copilot_how": "Check numbered sequences for gaps (for example, `-01-` exists but `-02-` is missing)"
+          "copilot_how": "Check numbered sequences for gaps (for example, `-01-` exists but `-02-` is missing)",
+          "antigravity_how": "Check numbered sequences for gaps (for example, `-01-` exists but `-02-` is missing)"
         },
         {
           "check": "Templates available",
           "claude_how": "Check `pdd/prompts/templates/` for `.template.md` files. If empty but 3 or more feature prompts exist with similar structure, suggest extracting a template.",
-          "copilot_how": "Check `pdd/prompts/templates/` for `.template.md` files. If empty but 3 or more feature prompts exist with similar structure, suggest extracting a template."
+          "copilot_how": "Check `pdd/prompts/templates/` for `.template.md` files. If empty but 3 or more feature prompts exist with similar structure, suggest extracting a template.",
+          "antigravity_how": "Check `pdd/prompts/templates/` for `.template.md` files. If empty but 3 or more feature prompts exist with similar structure, suggest extracting a template."
         }
       ]
     },
@@ -61,12 +70,14 @@
         {
           "check": "`pdd/evals/` has eval files",
           "claude_how": "Glob for `pdd/evals/*.md`",
-          "copilot_how": "Look for `pdd/evals/*.md`"
+          "copilot_how": "Look for `pdd/evals/*.md`",
+          "antigravity_how": "Glob for `pdd/evals/*.md`"
         },
         {
           "check": "Eval coverage",
           "claude_how": "Compare prompts in `pdd/prompts/features/` vs evals; flag prompts without evals",
-          "copilot_how": "Compare prompts in `pdd/prompts/features/` vs evals; flag prompts without evals"
+          "copilot_how": "Compare prompts in `pdd/prompts/features/` vs evals; flag prompts without evals",
+          "antigravity_how": "Compare prompts in `pdd/prompts/features/` vs evals; flag prompts without evals"
         }
       ]
     },
@@ -76,12 +87,14 @@
         {
           "check": "`src/` has committed artifacts",
           "claude_how": "Check if `src/` has files",
-          "copilot_how": "Check if `src/` has files"
+          "copilot_how": "Check if `src/` has files",
+          "antigravity_how": "Check if `src/` has files"
         },
         {
           "check": "Uncommitted AI output",
           "claude_how": "Check git status for untracked files outside the PDD structure",
-          "copilot_how": "Check git status for untracked files outside the PDD structure"
+          "copilot_how": "Check git status for untracked files outside the PDD structure",
+          "antigravity_how": "Check git status for untracked files outside the PDD structure"
         }
       ]
     }

--- a/core/metadata/workflows.json
+++ b/core/metadata/workflows.json
@@ -9,7 +9,8 @@
       "providers": {
         "claude": "/project:pdd-scaffold",
         "copilot": "/pdd-scaffold",
-        "codex": "scaffold"
+        "codex": "scaffold",
+        "antigravity": "/pdd-scaffold"
       }
     },
     {
@@ -21,7 +22,8 @@
       "providers": {
         "claude": "/project:pdd-init",
         "copilot": "/pdd-init",
-        "codex": "init"
+        "codex": "init",
+        "antigravity": "/pdd-init"
       }
     },
     {
@@ -33,7 +35,8 @@
       "providers": {
         "claude": "/project:pdd-context",
         "copilot": "/pdd-context",
-        "codex": "context"
+        "codex": "context",
+        "antigravity": "/pdd-context"
       }
     },
     {
@@ -45,7 +48,8 @@
       "providers": {
         "claude": "/project:pdd-research",
         "copilot": "/pdd-research",
-        "codex": "research"
+        "codex": "research",
+        "antigravity": "/pdd-research"
       }
     },
     {
@@ -57,7 +61,8 @@
       "providers": {
         "claude": "/project:pdd-plan",
         "copilot": "/pdd-plan",
-        "codex": "plan"
+        "codex": "plan",
+        "antigravity": "/pdd-plan"
       }
     },
     {
@@ -69,7 +74,8 @@
       "providers": {
         "claude": "/project:pdd-prompts",
         "copilot": "/pdd-prompts",
-        "codex": "prompts"
+        "codex": "prompts",
+        "antigravity": "/pdd-prompts"
       }
     },
     {
@@ -81,7 +87,8 @@
       "providers": {
         "claude": "/project:pdd-update",
         "copilot": "/pdd-update",
-        "codex": "update"
+        "codex": "update",
+        "antigravity": "/pdd-update"
       }
     },
     {
@@ -93,7 +100,8 @@
       "providers": {
         "claude": "/project:pdd-review",
         "copilot": "/pdd-review",
-        "codex": "review"
+        "codex": "review",
+        "antigravity": "/pdd-review"
       }
     },
     {
@@ -105,7 +113,8 @@
       "providers": {
         "claude": "/project:pdd-eval",
         "copilot": "/pdd-eval",
-        "codex": "eval"
+        "codex": "eval",
+        "antigravity": "/pdd-eval"
       }
     },
     {
@@ -117,7 +126,8 @@
       "providers": {
         "claude": "/project:pdd-status",
         "copilot": "/pdd-status",
-        "codex": "status"
+        "codex": "status",
+        "antigravity": "/pdd-status"
       }
     },
     {
@@ -129,7 +139,8 @@
       "providers": {
         "claude": "/project:pdd-help",
         "copilot": "/pdd-help",
-        "codex": "help"
+        "codex": "help",
+        "antigravity": "/pdd-help"
       }
     }
   ]

--- a/providers/antigravity/GEMINI.md
+++ b/providers/antigravity/GEMINI.md
@@ -1,0 +1,68 @@
+# Prompt Driven Development (PDD)
+
+You are a PDD-aware assistant. When the user is working on AI-assisted projects, apply these principles.
+
+## Project Type Detection
+
+Before helping with PDD workflows, detect the project type to tailor your guidance:
+
+1. Check `pdd/context/project.md` if it exists — look at the tech stack
+2. Infer from the user's language — framework names, tools, domain terms
+3. If unclear, ask: *"What kind of project is this — frontend, backend, mobile, data/ML, DevOps, or full-stack?"*
+
+| Project type | Signals |
+|---|---|
+| Frontend / UI | React, Vue, Angular, Svelte, CSS, Tailwind |
+| Backend / API | Node, FastAPI, Django, Rails, REST, GraphQL, databases |
+| Mobile | iOS, Android, Swift, Kotlin, React Native, Flutter |
+| Data / ML / AI | Python, Jupyter, pandas, PyTorch, pipelines |
+| DevOps / Infra | Terraform, Docker, Kubernetes, CI/CD, cloud providers |
+| Full-stack | Frontend + backend together, Next.js, Nuxt, SvelteKit |
+| Library / Package | npm package, PyPI library, crate, gem, Go module, SDK, "publish", `exports` map |
+| CLI / Developer Tools | CLI app, terminal tool, code generator, REPL, arg parsing, subcommands, shell completions |
+| Embedded / IoT | MCU, RTOS, bare-metal, Arduino, ESP32, STM32, Zephyr, FreeRTOS, firmware |
+| Game Development | Unity, Unreal, Godot, Bevy, game engine, ECS, frame budget, sprites, shaders |
+| Blockchain / Smart Contracts | Solidity, Vyper, Rust/Anchor, Move, Hardhat, Foundry, EVM, Solana, DeFi, NFT, smart contract |
+| Security / Pentesting Tools | Scanner, fuzzer, exploit framework, SIEM, detection rules, pentest, red team, blue team, vulnerability |
+| API Platform / SDK | Public API, developer platform, API-as-product, OpenAPI, SDK generation, rate limiting, webhooks, API versioning |
+| Desktop / Native GUI | Tauri, Electron, Flutter desktop, SwiftUI macOS, Qt, .NET MAUI, WPF, window management, system tray, code signing, auto-update |
+| Compiler / Language Tooling | Compiler, interpreter, transpiler, linter, formatter, LSP server, parser, AST, type checker, codegen, tree-sitter |
+| Robotics / ROS | ROS, ROS2, robot, manipulator, drone, autonomous vehicle, URDF, Gazebo, MoveIt, Nav2, sensor fusion, SLAM |
+
+Reference files for each project type live in `.agent/references/`. Load the matching one to shape context questions, conventions, and review checklists.
+
+## Core Principles
+
+<!-- GENERATED:antigravity-principles:start -->
+- **One prompt, one job.** Split if multiple concerns.
+- **Commit prompts alongside outputs.** The prompt is part of the codebase.
+- **Update context after every significant decision.** Stale context degrades future prompts.
+- **Timebox experiments.** Name with a date prefix (`YYYY-MM-DD-`). After one week: promote to `pdd/prompts/features/` if it worked, delete if it didn't.
+- **Never commit unreviewed output.** Treat it like a PR.
+- **Context must reflect reality.** Aspirational `project.md` actively misleads.
+<!-- GENERATED:antigravity-principles:end -->
+
+## Workflow Routing
+
+<!-- GENERATED:antigravity-routing-table:start -->
+| User intent | Use |
+|---|---|
+| Start a new project / set up structure | Use `/pdd-scaffold` |
+| Add PDD to an existing project | Use `/pdd-init` |
+| Write or update context files | Use `/pdd-context` |
+| Explore a problem space, find existing solutions, evaluate approaches | Use `/pdd-research` |
+| Plan a feature before writing prompts | Use `/pdd-plan` |
+| Write a feature prompt | Use `/pdd-prompts` |
+| Fix a prompt that isn't working | Use `/pdd-update` |
+| Review AI-generated code (includes quality checks) | Use `/pdd-review` |
+| Track prompt quality and pass rates | Use `/pdd-eval` |
+| Check project PDD health | Use `/pdd-status` |
+| List available commands / how PDD works / get help | Use `/pdd-help` |
+<!-- GENERATED:antigravity-routing-table:end -->
+
+## Output Expectations
+
+- Be explicit about which PDD workflow you are using.
+- Produce durable artifacts in the repo when the task calls for it.
+- Suggest the next workflow after finishing the current one.
+- Keep the user moving instead of leaving them with a generic explanation only.

--- a/providers/antigravity/README.md
+++ b/providers/antigravity/README.md
@@ -1,0 +1,123 @@
+# PDD Skill for Google Antigravity
+
+The same Prompt Driven Development workflows, adapted for Google Antigravity (the agentic IDE Google launched in November 2025).
+
+Parts of this document are generated from shared metadata so provider terminology stays aligned.
+
+## Setup
+
+From the repo root, copy these files into your project:
+
+```bash
+# Copy the workspace rules (always-on)
+cp providers/antigravity/GEMINI.md <your-project>/GEMINI.md
+
+# Copy the skill entrypoint
+mkdir -p <your-project>/.agents/skills/pdd
+cp providers/antigravity/skills/pdd/SKILL.md <your-project>/.agents/skills/pdd/SKILL.md
+
+# Copy the workflow files
+mkdir -p <your-project>/.agent/workflows
+cp providers/antigravity/workflows/*.md <your-project>/.agent/workflows/
+
+# Copy the reference files (project type flavors)
+mkdir -p <your-project>/.agent/references
+cp -r core/references/* <your-project>/.agent/references/
+```
+
+Your project should end up with:
+
+```
+GEMINI.md
+.agents/skills/pdd/SKILL.md
+.agent/workflows/
+  pdd-scaffold.md
+  pdd-init.md
+  pdd-context.md
+  pdd-research.md
+  pdd-plan.md
+  pdd-prompts.md
+  pdd-update.md
+  pdd-review.md
+  pdd-eval.md
+  pdd-status.md
+  pdd-help.md
+.agent/references/
+  frontend.md
+  backend.md
+  mobile.md
+  data-ml.md
+  devops.md
+  fullstack.md
+  library.md
+  cli-devtools.md
+  embedded-iot.md
+  game-dev.md
+  blockchain.md
+  security.md
+  api-platform.md
+  desktop-gui.md
+  compiler-lang.md
+  robotics.md
+```
+
+## Usage
+
+In Antigravity (CLI or IDE), the workflow files auto-expose as slash commands. Type `/` to see them, then select one:
+
+<!-- GENERATED:antigravity-command-table:start -->
+| Command | What it does |
+|---|---|
+| `/pdd-scaffold` | Set up a new PDD project with folders, context stubs, and starter guidance. |
+| `/pdd-init` | Add PDD structure to an existing repository and infer a starting context. |
+| `/pdd-context` | Write or update the persistent project context files that future prompts depend on. |
+| `/pdd-research` | Explore the problem space, evaluate options, and decide what to build. |
+| `/pdd-plan` | Break a feature into phases and decide the prompt chain strategy before coding. |
+| `/pdd-prompts` | Generate focused feature prompts and place them in the right PDD folder. |
+| `/pdd-update` | Diagnose and improve a prompt that is producing weak or incorrect output. |
+| `/pdd-review` | Verify and review AI-generated output before it is committed. |
+| `/pdd-eval` | Track prompt quality over time with repeatable evaluation criteria. |
+| `/pdd-status` | Check what PDD artifacts exist, what is stale, and what to do next. |
+| `/pdd-help` | Show the available workflows, when to use them, and the typical sequence. |
+<!-- GENERATED:antigravity-command-table:end -->
+
+The `GEMINI.md` workspace rules file loads automatically each session, providing PDD-aware routing and core principles.
+
+## Workflow
+
+```mermaid
+flowchart LR
+    A["/pdd-scaffold (new)"] --> B["/pdd-context"]
+    A2["/pdd-init (existing)"] --> B
+    B --> S{Complex?}
+    S -- Yes --> C["/pdd-research"] --> D["/pdd-plan"] --> E
+    S -- No --> E["/pdd-prompts"]
+    E --> F["Run prompt"]
+    F --> G["/pdd-review"]
+    G --> H["Commit"]
+    H -.-> I["/pdd-eval"]
+
+    style A2 fill:#3498db,stroke:#2980b9,color:#fff
+    style S fill:#f1c40f,stroke:#d4ac0d,color:#333
+    style C fill:#1abc9c,stroke:#17a589,color:#fff
+    style D fill:#1abc9c,stroke:#17a589,color:#fff
+    style I fill:#f4a460,stroke:#c4824a,color:#fff
+```
+
+**Quick path**: `/pdd-context` → `/pdd-prompts` → `/pdd-review` → commit. Use `/pdd-init` instead of `/pdd-scaffold` for existing projects. Add `/pdd-research` and `/pdd-plan` for complex features. Use `/pdd-eval` to track prompt reliability over time.
+
+Each workflow file suggests the next step at the end, so you don't need to memorize the flow.
+
+## Differences from the other adapters
+
+| Aspect | Claude / Copilot / Codex | Antigravity |
+|---|---|---|
+| Workspace rules filename | `CLAUDE.md` / `.github/copilot-instructions.md` / `AGENTS.md` | `GEMINI.md` (Antigravity-specific to avoid `AGENTS.md` collisions with other tools) |
+| File-reference syntax in prompts | `#file:references/foo.md` (Copilot) or plain prose (Claude) | Plain prose only — Antigravity has no documented `#file:` equivalent |
+| Subagent definitions | Static persona files (Claude `.claude/agents/`, Copilot `.github/agents/`) | Not user-declarable; the orchestrator spawns subagents dynamically at runtime |
+| Plugin manifest | `plugin.json` (Claude) / `.codex-plugin/plugin.json` (Codex) | Skipped for v1 — Antigravity's plugin schema is not publicly documented |
+
+## Requirements
+
+- Google Antigravity, CLI or IDE (public preview, November 2025+)
+- A Gemini-compatible config directory (`~/.gemini/`) for any global skills or MCP servers you also want to install

--- a/providers/antigravity/skills/pdd/SKILL.md
+++ b/providers/antigravity/skills/pdd/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: pdd
+description: >-
+  Trigger when the user mentions PDD, wants to scaffold an AI-assisted project,
+  write context or prompt files, improve prompts, or review AI-generated output.
+  Also trigger for: "structure my AI project", "organize my prompts", or
+  "review this AI code" -- even without the term PDD.
+---
+
+# Prompt Driven Development (PDD) Skill
+
+This skill turns Antigravity into a PDD partner — helping users structure, operate, and improve AI-assisted development projects.
+
+**Nine core workflows:**
+<!-- GENERATED:antigravity-workflow-overview:start -->
+1. **Scaffold** — set up a new project folder structure
+2. **Init** — add PDD to an existing project (auto-detects stack and conventions)
+3. **Context** — write or update context files (`project.md`, `conventions.md`, `decisions.md`)
+4. **Research** — explore a problem space, evaluate approaches, and decide what to build
+5. **Plan** — decompose a feature into phases and a prompt chain strategy
+6. **Prompts** — generate well-structured feature prompts
+7. **Update** — improve or refactor an existing prompt
+8. **Review** — verify and review AI-generated output before committing (includes automated quality checks)
+9. **Eval** — run prompt evaluations and track quality over time
+<!-- GENERATED:antigravity-workflow-overview:end -->
+
+<!-- GENERATED:antigravity-quick-path:start -->
+**Quick path**: For simple features, you only need **Context -> Prompts -> Review**. Research, Plan, and Eval add value for complex or critical features but are not required for every task. Use **Init** instead of Scaffold when adding PDD to a project that already has code.
+<!-- GENERATED:antigravity-quick-path:end -->
+
+---
+
+## Step 0: Identify what the user needs
+
+<!-- GENERATED:antigravity-routing-table:start -->
+| User intent | Use |
+|---|---|
+| Start a new project / set up structure | Use `/pdd-scaffold` |
+| Add PDD to an existing project | Use `/pdd-init` |
+| Write or update context files | Use `/pdd-context` |
+| Explore a problem space, find existing solutions, evaluate approaches | Use `/pdd-research` |
+| Plan a feature before writing prompts | Use `/pdd-plan` |
+| Write a feature prompt | Use `/pdd-prompts` |
+| Fix a prompt that isn't working | Use `/pdd-update` |
+| Review AI-generated code (includes quality checks) | Use `/pdd-review` |
+| Track prompt quality and pass rates | Use `/pdd-eval` |
+| Check project PDD health | Use `/pdd-status` |
+| List available commands / how PDD works / get help | Use `/pdd-help` |
+<!-- GENERATED:antigravity-routing-table:end -->
+
+| Vague or unclear | → Ask: *"Are you starting a new project, working on a feature prompt, or reviewing something the AI generated?"* |
+
+**If context files don't exist yet:** Don't block the user. Proceed with the requested workflow and suggest context files afterward.
+
+### Returning to an existing PDD project
+
+When context files already exist, check freshness first: *"Has anything changed since your context files were last updated?"* If yes → run `/pdd-context` before proceeding.
+
+### Workflow transitions
+
+After completing any workflow, suggest the natural next step:
+
+<!-- GENERATED:antigravity-workflow-transitions:start -->
+| Just finished | Suggest next |
+|---|---|
+| **Scaffold** | -> Context: *"Structure is ready. Want to write `pdd/context/project.md`?"* |
+| **Init** | -> Context: *"PDD structure is ready. Run `/project:pdd-context` to fill in your context files; I'll use what I detected as a starting point."* |
+| **Context** | -> Research or Plan: *"Context is set. Before writing prompts, want to research the problem space or plan the implementation?"* |
+| **Research** - adopt/extend/compose | -> Help install/configure, or create a prompt adapting the solution |
+| **Research** - build | -> Plan: *"Nothing existing fits. Let's plan the implementation."* |
+| **Plan** | -> Prompts: *"Plan is set. Ready to write the first prompt? Start with Phase 1."* |
+| **Prompts** | -> Run the prompt 2 to 3 times, then -> Review: *"Run this prompt, then `/project:pdd-review` to verify and review the output."* For critical prompts, create a Level 1 eval first. |
+| **Update** | -> Re-run the prompt, then -> Review: *"Try the updated prompt and run `/project:pdd-review` on the output."* |
+| **Review** - issues found | -> Fix code, or -> Update if the prompt needs work |
+| **Review** - looks good | -> Commit both prompt and output. -> Eval: *"Consider running `/project:pdd-eval` to track this prompt's quality over time."* |
+| **Eval** - passes | -> Level up the eval if 5 or more runs, or continue to next feature |
+| **Eval** - fails | -> Update: *"These criteria failed. Fix the prompt first."* |
+<!-- GENERATED:antigravity-workflow-transitions:end -->
+
+---
+
+## General Principles
+
+<!-- GENERATED:antigravity-principles:start -->
+- **One prompt, one job.** Split if multiple concerns.
+- **Commit prompts alongside outputs.** The prompt is part of the codebase.
+- **Update context after every significant decision.** Stale context degrades future prompts.
+- **Timebox experiments.** Name with a date prefix (`YYYY-MM-DD-`). After one week: promote to `pdd/prompts/features/` if it worked, delete if it didn't.
+- **Never commit unreviewed output.** Treat it like a PR.
+- **Context must reflect reality.** Aspirational `project.md` actively misleads.
+<!-- GENERATED:antigravity-principles:end -->
+
+---
+
+## Common Situations
+
+**"I don't know where to start"** → Ask if they have a project in mind, then Scaffold + Context or define the project first.
+
+**"This is too complicated"** → Start with just `pdd/context/project.md`. Everything else can come later.
+
+**"I'm mid-project and things are messy"** → Init to add PDD structure, then write context files for what exists now. Apply full workflow to new work only.
+
+**"My team doesn't know about PDD"** → Start with `pdd/context/` layer — reads as plain docs, no workflow change required.
+
+**"The prompt didn't work at all"** → Update. Diagnose before rewriting.
+
+**"Is this code ready to commit?"** → Review. Runs automated checks first, then detailed review.
+
+**"How reliable is this prompt?"** → Eval. Track pass rates across runs.
+
+**"Can you just do it for me?"** → Yes — but explain each step so the user learns the pattern.

--- a/providers/antigravity/workflows/pdd-context.md
+++ b/providers/antigravity/workflows/pdd-context.md
@@ -1,0 +1,140 @@
+# Write PDD Context Files
+
+This is the Antigravity adapter for the shared `Context` workflow in `core/workflows/context.md`. Keep shared workflow behavior aligned there; this file exists to preserve Antigravity-specific `/pdd-*` command wording.
+
+## Purpose
+
+Write or update the persistent project context layer so future prompts are grounded in real project constraints.
+
+**Write what is true, not what you hope will be true.** Stale or aspirational context makes every later prompt worse.
+
+## Use When
+
+- Context files do not exist yet.
+- The stack, constraints, or architectural decisions have changed.
+- The user wants better prompt quality and consistency.
+- You need to refresh context after research, planning, or a major implementation decision.
+
+## Inputs
+
+- What the project is
+- who it is for
+- the tech stack
+- quality expectations
+- hard constraints and anti-patterns
+- current implementation state
+
+## Detect Project Type First
+
+Load the matching project-type reference file from `references/` to get type-specific questions, conventions, and templates. Provider adapters may translate these paths into provider-specific syntax, but the underlying reference files should stay aligned.
+
+| Type | Signals | Reference |
+|---|---|---|
+| Frontend / UI | React, Vue, Angular, Svelte, CSS, Tailwind | `references/frontend.md` |
+| Backend / API | Node, FastAPI, Django, Rails, REST, GraphQL, gRPC, databases | `references/backend.md` |
+| Mobile | iOS, Android, Swift, Kotlin, React Native, Flutter, Expo | `references/mobile.md` |
+| Data / ML / AI | Python, Jupyter, pandas, PyTorch, scikit-learn, pipelines | `references/data-ml.md` |
+| DevOps / Infra | Terraform, Docker, Kubernetes, CI/CD, AWS, GCP, Azure | `references/devops.md` |
+| Full-stack | Frontend + backend, Next.js, Nuxt, SvelteKit | `references/fullstack.md` + `references/frontend.md` + `references/backend.md` |
+| Library / Package | npm package, PyPI library, crate, gem, Go module, SDK | `references/library.md` (+ domain flavor if applicable) |
+| CLI / Developer Tools | CLI app, terminal tool, code generator, REPL, arg parsing, subcommands | `references/cli-devtools.md` |
+| Embedded / IoT | MCU, RTOS, bare-metal, Arduino, ESP32, STM32, Zephyr, FreeRTOS, firmware | `references/embedded-iot.md` |
+| Game Development | Unity, Unreal, Godot, Bevy, game engine, ECS, frame budget | `references/game-dev.md` |
+| Blockchain / Smart Contracts | Solidity, Vyper, Rust/Anchor, Hardhat, Foundry, EVM, Solana, DeFi | `references/blockchain.md` |
+| Security / Pentesting Tools | Scanner, fuzzer, exploit framework, SIEM, detection rules, pentest | `references/security.md` |
+| API Platform / SDK | Public API, developer platform, OpenAPI, SDK generation, rate limiting, webhooks | `references/api-platform.md` |
+| Desktop / Native GUI | Tauri, Electron, Flutter desktop, SwiftUI macOS, Qt, .NET MAUI, WPF | `references/desktop-gui.md` |
+| Compiler / Language Tooling | Compiler, interpreter, transpiler, linter, formatter, LSP server, parser, AST | `references/compiler-lang.md` |
+| Robotics / ROS | ROS, ROS2, robot, drone, autonomous vehicle, URDF, Gazebo, MoveIt, Nav2 | `references/robotics.md` |
+
+**Full-stack merge priority**: When `fullstack.md`, `frontend.md`, and `backend.md` are loaded together, `fullstack.md` conventions take precedence where they overlap. Fall through to the frontend or backend reference only for concerns `fullstack.md` does not address.
+
+**Library is composable**: A project can be both a library and a domain type. When combined, `library.md` takes precedence for API surface, versioning, and distribution; the domain flavor takes precedence for implementation patterns.
+
+If the project spans multiple types, load all relevant references. When conventions conflict, surface the conflict and record the decision in `pdd/context/decisions.md`.
+
+## Produces
+
+- `pdd/context/project.md`
+- `pdd/context/conventions.md`
+- `pdd/context/decisions.md`
+
+## If Creating New Context Files
+
+Ask these questions conversationally, not as a single long form:
+
+1. What are you building, and who is it for?
+2. What's the tech stack?
+3. What does good output look like?
+4. What should the AI never do or suggest?
+5. What's already been built?
+
+Then ask any type-specific questions from the matching reference file.
+
+### `pdd/context/project.md`
+
+Use this as the shared base template:
+
+```markdown
+# Project: <name>
+
+## What we're building
+<1-2 sentence description>
+
+## Who it's for
+<target users or stakeholders>
+
+## Tech stack
+- Language:
+- Framework:
+- Database:
+- Deployment:
+
+## What good output looks like
+<quality bar, style expectations, standards>
+
+## Constraints (what the AI should never do or suggest)
+- <constraint>
+
+## Current state
+<what's already built, or "Starting from scratch">
+```
+
+Extend it with type-specific sections from the relevant reference file.
+
+### `pdd/context/conventions.md`
+
+Ask whether the user has code style preferences or patterns the AI should always follow.
+
+Capture naming, file structure, error handling, testing expectations, and persistent AI instructions. Even a short draft is useful; the file can grow over time.
+
+### `pdd/context/decisions.md`
+
+Record important architectural decisions using a durable format:
+
+```markdown
+## Decision: <short title>
+**Date**: <approximate>
+**What was decided**: <the decision>
+**Why**: <rationale>
+**Don't suggest**: <alternatives to avoid>
+```
+
+## If Updating Existing Context Files
+
+1. Read the existing files first.
+2. Ask what changed: stack, decisions, constraints, or current state.
+3. Update only stale sections instead of rewriting everything.
+4. Add `**Last updated**: <date>` to modified files.
+5. If the codebase is available, compare what the context claims with what actually exists.
+
+## Edge Cases
+
+- **Monorepo**: keep a root `pdd/context/project.md` for the system, plus sub-project context where needed.
+- **Team project**: prioritize `conventions.md` and pull from existing linters or style guides when possible.
+- **Context too long**: split deeper material into `architecture.md` or another supporting doc once the overview becomes hard to scan.
+- **Partial info**: draft with placeholders rather than leaving the project without context.
+
+## Default Next Step
+
+For simple work, move to `/pdd-prompts`. For higher-risk or ambiguous work, move to `/pdd-research` or `/pdd-plan`. Provider adapters should suggest the provider-specific command or workflow name that matches that transition.

--- a/providers/antigravity/workflows/pdd-eval.md
+++ b/providers/antigravity/workflows/pdd-eval.md
@@ -1,0 +1,124 @@
+# Run Prompt Evaluations
+
+This is the Antigravity adapter for the shared `Eval` workflow in `core/workflows/eval.md`. Keep shared workflow behavior aligned there; this file exists to preserve Antigravity-specific `/pdd-*` command wording.
+
+## Purpose
+
+Track prompt quality over time with explicit criteria instead of relying on memory or one successful run.
+
+An eval turns "this felt good once" into something measurable. It gives the team a repeatable signal for prompt reliability and helps catch drift early.
+
+## Use When
+
+- A prompt matters enough to measure repeatedly.
+- The team wants a baseline or regression signal.
+- A once-good prompt has started to drift.
+- The team wants confidence before reusing or promoting a prompt.
+
+## Inputs
+
+- prompt under test
+- expected outputs or acceptance criteria
+- baseline artifacts when available
+
+## Step 1: Identify What To Evaluate
+
+If the user names a prompt, evaluate that one.
+
+Otherwise, prefer prompts that are:
+
+- high-impact
+- used often
+- not yet covered by an eval
+- suspected of drifting
+
+## Step 2: Check For An Existing Eval
+
+Look in `pdd/evals/` for a matching eval file, usually named `<prompt-name>-eval.md`.
+
+If none exists, create a Level 1 manual checklist like:
+
+```markdown
+# Eval: <prompt name>
+**Prompt**: pdd/prompts/features/<area>/<prompt-file>.md
+**Created**: <date>
+**Level**: 1 — Manual checklist
+
+## Criteria
+- [ ] Output compiles / runs without errors
+- [ ] Matches the specified output format
+- [ ] Handles the listed edge cases
+- [ ] Follows project conventions
+- [ ] No hallucinated imports, APIs, or functions
+- [ ] Integrates with existing code without conflicts
+
+## Type-specific criteria
+<add checks from the project type reference file>
+
+## Run log
+
+| Run | Date | Result | Notes |
+|---|---|---|---|
+| 1 | <date> | <pass/fail> | <what happened> |
+```
+
+## Step 3: Run The Evaluation
+
+Use the latest prompt output or ask the user to run the prompt if no output is available.
+
+For each evaluation run:
+
+1. check every criterion
+2. mark pass or fail
+3. log the run
+4. summarize the overall result
+
+## Pass-Rate Tracking
+
+After 3 or more runs, track useful signals such as:
+
+- **pass@1**: passes on the first try
+- **pass@3**: passes at least once within three tries
+
+## Step 4: Level Up When Ready
+
+| Current level | Trigger to level up | Action |
+|---|---|---|
+| **Level 1** | 5+ runs of the same prompt | Save a known-good baseline |
+| **Level 2** | Stable, frequently used prompt | Add scripted validation |
+
+### Level 2
+
+Save a known-good output under `pdd/evals/baselines/` and compare future outputs against it.
+
+### Level 3
+
+For mature prompts, add validation scripts under `pdd/evals/scripts/`.
+
+## Produces
+
+- evaluation notes or files under `pdd/evals/`
+- pass/fail signals
+- follow-up recommendations when quality drops
+
+## Reporting
+
+Use a compact report that includes:
+
+- eval level
+- run number and date
+- pass/fail result
+- criteria results
+- pass-rate summary when enough runs exist
+- recommendation
+
+## Edge Cases
+
+- **No prompt output available**: ask the user to run it first, or run it if possible
+- **No eval exists yet**: create Level 1 and perform the first run
+- **All prompts already have evals**: report coverage and suggest the least recently evaluated prompt
+- **Criteria are outdated**: update the eval to match what quality now means for that prompt
+
+## Default Next Step
+
+If the eval fails, move to `/pdd-update`. If it passes consistently, keep the prompt in active use.

--- a/providers/antigravity/workflows/pdd-help.md
+++ b/providers/antigravity/workflows/pdd-help.md
@@ -1,8 +1,3 @@
----
-agent: agent
-description: "Quick reference for all PDD commands, workflow order, and usage guidance"
----
-
 # PDD Help
 
 > **Version**: v1.4.0-3-gf83deb4
@@ -29,13 +24,13 @@ Show the full quick reference below.
 
 ### Quick start
 
-<!-- GENERATED:copilot-help-quick-start:start -->
+<!-- GENERATED:antigravity-help-quick-start:start -->
 > **Quick start**: For most features, you only need three commands: **Context -> Prompts -> Review**. Add Research, Plan, and Eval for complex or critical features.
-<!-- GENERATED:copilot-help-quick-start:end -->
+<!-- GENERATED:antigravity-help-quick-start:end -->
 
 ### All commands
 
-<!-- GENERATED:copilot-help-command-groups:start -->
+<!-- GENERATED:antigravity-help-command-groups:start -->
 **Getting started**
 
 | Command | What it does |
@@ -61,11 +56,11 @@ Show the full quick reference below.
 |---|---|
 | `/pdd-review` | Verify and review AI-generated output before it is committed. |
 | `/pdd-eval` | Track prompt quality over time with repeatable evaluation criteria. |
-<!-- GENERATED:copilot-help-command-groups:end -->
+<!-- GENERATED:antigravity-help-command-groups:end -->
 
 ### "What should I use?"
 
-<!-- GENERATED:copilot-help-scenarios:start -->
+<!-- GENERATED:antigravity-help-scenarios:start -->
 | I want to... | Use |
 |---|---|
 | Start a brand new project | `/pdd-scaffold` -> `/pdd-context` |
@@ -75,13 +70,13 @@ Show the full quick reference below.
 | Fix a prompt that isn't working | `/pdd-update` |
 | Check if my project setup is complete | `/pdd-status` |
 | Track prompt quality over time | `/pdd-eval` |
-<!-- GENERATED:copilot-help-scenarios:end -->
+<!-- GENERATED:antigravity-help-scenarios:end -->
 
 ### Per-command detail
 
 Use this table when the user asks about a specific command.
 
-<!-- GENERATED:copilot-help-command-detail:start -->
+<!-- GENERATED:antigravity-help-command-detail:start -->
 | Command | When to use | Inputs | Produces | Next step |
 |---|---|---|---|---|
 | `pdd-scaffold` | Starting a brand new project from scratch | Project name (optional) | Folder structure with context stubs | `/pdd-context` |
@@ -95,4 +90,4 @@ Use this table when the user asks about a specific command.
 | `pdd-eval` | After committing, to track prompt reliability | Prompt file plus expected outcomes | Eval results in `pdd/evals/` | Update the prompt if quality drops |
 | `pdd-status` | When you want to check project health | None | Status report with suggestions | Whatever the report recommends |
 | `pdd-help` | When you want to see available commands | Command name (optional) | This reference | Whatever workflow fits |
-<!-- GENERATED:copilot-help-command-detail:end -->
+<!-- GENERATED:antigravity-help-command-detail:end -->

--- a/providers/antigravity/workflows/pdd-init.md
+++ b/providers/antigravity/workflows/pdd-init.md
@@ -1,0 +1,104 @@
+# Initialize PDD in an Existing Project
+
+This is the Antigravity adapter for the shared `Init` workflow in `core/workflows/init.md`. Keep shared workflow behavior aligned there; this file exists to preserve Antigravity-specific `/pdd-*` command wording.
+
+## Purpose
+
+Add PDD structure to an existing repository without pretending the project is starting fresh.
+
+Init should preserve reality. It adds the PDD layer to an existing codebase, detects what already exists, and hands off into `/pdd-context` with a truthful starting point.
+
+## Use When
+
+- The codebase already exists.
+- The user wants to introduce PDD incrementally.
+- The repo already has source layout, tooling, and conventions worth detecting instead of recreating.
+
+## Inputs
+
+- Existing repository layout
+- detectable stack and conventions
+- any known constraints the AI should follow
+
+## Step 1: Confirm This Is An Existing Project
+
+Check for signs of an established codebase:
+
+- git repository
+- source files
+- dependency manifests
+- existing build or lint configuration
+
+If the directory looks empty or brand new, route to `/pdd-scaffold` instead.
+
+## Step 2: Guard Against Overwrite
+
+If `pdd/` already exists, do not overwrite it silently. Confirm whether the user wants to fill in missing pieces or stop.
+
+## Step 3: Detect The Project Shape
+
+Infer:
+
+- project type
+- tech stack
+- likely source directories
+- existing conventions from linting and formatting config
+
+If multiple project types match, surface that and ask the user to confirm the primary type instead of guessing.
+
+## Step 4: Create Only The PDD Layer
+
+Create just the `pdd/` structure:
+
+```text
+pdd/
+  prompts/
+    features/
+    templates/
+    experiments/
+  context/
+    project.md
+    conventions.md
+    decisions.md
+  evals/
+    baselines/
+    scripts/
+```
+
+Do not create a new source directory, do not create a new project root, and do not initialize git.
+
+## Step 5: Present A Detection Summary
+
+Summarize:
+
+- inferred project type
+- detected languages and frameworks
+- likely source directories
+- notable conventions from tool configs
+- what was created under `pdd/`
+
+Ask the user to confirm what is correct and what needs adjustment before moving on.
+
+## Produces
+
+- PDD folders added to the repo
+- an initial understanding of the project shape
+- a handoff into context refinement
+
+## Rules
+
+- never create a new project directory
+- never run `git init`
+- never modify source directories during init
+- never overwrite existing `pdd/` files without explicit confirmation
+- if detection is uncertain, say so
+
+## Edge Cases
+
+- **Multiple project types match**: surface all likely matches and ask for confirmation
+- **Monorepo**: initialize the root thoughtfully and note likely sub-project boundaries
+- **Existing partial PDD setup**: fill in gaps instead of pretending the project is uninitialized
+
+## Default Next Step
+
+Move to `/pdd-context` and write what is true today, not what the team hopes to build later.

--- a/providers/antigravity/workflows/pdd-plan.md
+++ b/providers/antigravity/workflows/pdd-plan.md
@@ -1,0 +1,103 @@
+# Plan Before Prompting
+
+This is the Antigravity adapter for the shared `Plan` workflow in `core/workflows/plan.md`. Keep shared workflow behavior aligned there; this file exists to preserve Antigravity-specific `/pdd-*` command wording.
+
+## Purpose
+
+Break a feature into phases and decide the prompt-chain strategy before generating implementation prompts.
+
+Planning prevents oversized prompts, hidden dependencies, and accidental architecture decisions. The goal is to make implementation sequencing explicit before code generation begins.
+
+## Use When
+
+- The feature spans multiple files, layers, or phases.
+- A single prompt would mix too many concerns.
+- The team needs sequencing before coding.
+- The work has enough ambiguity or risk that a prompt chain should be designed intentionally.
+
+## Inputs
+
+- feature goal
+- current context files
+- research results if available
+
+## Step 1: Load Context
+
+Read `pdd/context/project.md`, `conventions.md`, and `decisions.md` if they exist. Scan existing prompts in `pdd/prompts/features/` to see what already exists.
+
+Load the matching project-type reference file to pick the right decomposition patterns for the stack.
+
+If context is missing, proceed carefully but flag that as a planning risk.
+
+## Step 2: Understand The Feature
+
+Ask conversationally:
+
+- What are you trying to build?
+- What does "done" look like?
+- What already exists that this connects to?
+- What unknowns or decisions are still open?
+
+## Step 3: Decompose Into Phases
+
+Break the feature into ordered phases. Each phase should produce one concrete, testable artifact and map to exactly one prompt.
+
+Use a structure like:
+
+```markdown
+# Implementation Plan: <feature name>
+**Created**: <date>
+**Complexity**: Low | Medium | High
+**Estimated prompts**: <count>
+
+## Summary
+<2-3 sentence overview of the approach>
+
+## Phases
+
+### Phase 1: <name>
+**Produces**: <concrete artifact>
+**Depends on**: nothing | Phase N | existing code
+**Risk**: Low | Medium | High — <why>
+**Prompt**: `pdd/prompts/features/<area>/<feature>-01-<phase>.md`
+
+### Phase 2: <name>
+...
+
+## Risks & Unknowns
+- <anything that needs investigation or a decision before proceeding>
+
+## Decisions Needed
+- <architectural choices to log in decisions.md>
+```
+
+## Step 4: Review The Plan
+
+Before writing prompts, check whether:
+
+- the decomposition feels right
+- any phases should start as experiments
+- any decisions should be resolved first
+
+Do not rush into prompts if the phase boundaries or dependencies are still unclear.
+
+## Produces
+
+- phased implementation outline
+- prompt-chain order
+- checkpoints for review and validation
+
+## Step 5: Save The Plan
+
+Save the plan to `pdd/prompts/features/<area>/PLAN-<feature-name>.md` so it becomes the reference for the prompt chain.
+
+## Edge Cases
+
+- **Trivial feature**: skip planning and go directly to `/pdd-prompts`
+- **Unknowns dominate**: suggest an experiment prompt first
+- **Plan changes mid-implementation**: update the plan file and adjust remaining prompts
+- **Multiple unrelated features**: create separate plans instead of combining them
+
+## Default Next Step
+
+Move to `/pdd-prompts` and generate the first focused implementation prompt.

--- a/providers/antigravity/workflows/pdd-prompts.md
+++ b/providers/antigravity/workflows/pdd-prompts.md
@@ -1,0 +1,114 @@
+# Generate a Feature Prompt
+
+This is the Antigravity adapter for the shared `Prompts` workflow in `core/workflows/prompts.md`. Keep shared workflow behavior aligned there; this file exists to preserve Antigravity-specific `/pdd-*` command wording.
+
+## Purpose
+
+Create focused, versionable prompt artifacts that ask the AI to do one job well.
+
+Prompts should be durable project artifacts, not one-off chat messages. Each prompt should have a single job, a clear file path, and a reviewable output expectation.
+
+## Use When
+
+- The team is ready to implement a planned change.
+- Context is already in place or good enough to proceed.
+- A feature is small enough to prompt directly or already decomposed into clear phases.
+
+## Inputs
+
+- feature description
+- current context files
+- plan or research notes if they exist
+
+## Step 1: Load Context
+
+Read the relevant project context first. If `pdd/context/project.md` exists, use it. Pull in conventions and decisions if they affect the requested feature.
+
+Load the matching project-type reference file for prompt patterns, common feature concerns, and type-specific expectations.
+
+If context is missing, continue but note that a later `/pdd-context` pass would improve prompt quality.
+
+## Step 2: Decompose If Needed
+
+Watch for work that should be split before writing prompts:
+
+- multiple unrelated outputs
+- backend and frontend bundled together
+- implementation plus tests plus refactor all in one ask
+
+If the task is too broad, split it into smaller prompts before writing anything.
+
+## Step 3: Gather Task Details
+
+Ask for the details needed to make the prompt precise:
+
+- what the feature does
+- inputs and expected outputs
+- constraints and edge cases
+- surrounding code or modules it must fit into
+
+## Step 4: Write The Prompt
+
+Before writing from scratch, check whether an existing template in `pdd/prompts/templates/` already fits.
+
+Use a structure like:
+
+```markdown
+# Prompt: <feature name>
+**File**: pdd/prompts/features/<area>/<feature-name>.md
+**Created**: <date>
+**Project type**: <detected type>
+
+## Context
+<relevant context>
+
+## Task
+<single, clear instruction>
+
+## Input
+<what the AI is working with>
+
+## Output format
+<what should be returned>
+
+## Constraints
+- <constraint>
+
+## Examples (optional but recommended)
+Input: <example>
+Output: <example>
+```
+
+Save prompts under `pdd/prompts/features/<area>/`, `pdd/prompts/templates/`, or `pdd/prompts/experiments/` depending on maturity and reuse.
+
+## Prompt Chaining
+
+For multi-step features with dependencies:
+
+- number prompts in order
+- include dependencies between steps
+- review each step before running the next
+
+If one step fails, fix it and re-run downstream steps as needed instead of restarting the entire chain.
+
+## Produces
+
+- prompt files under `pdd/prompts/features/`, `templates/`, or `experiments/`
+- clear run instructions and expected review follow-up
+
+## Edge Cases
+
+- **Vague goal**: break it into a feature list first
+- **Prompt keeps failing**: route to `/pdd-update`
+- **Exploratory work**: save to `pdd/prompts/experiments/` with a date prefix
+- **Recurring structure**: extract a reusable template
+
+## Default Storage Guidance
+
+- stable implementation work -> `pdd/prompts/features/`
+- repeated pattern -> `pdd/prompts/templates/`
+- exploratory or uncertain work -> `pdd/prompts/experiments/`
+
+## Default Next Step
+
+Run the prompt, inspect the output, and move to `/pdd-review` before committing anything.

--- a/providers/antigravity/workflows/pdd-research.md
+++ b/providers/antigravity/workflows/pdd-research.md
@@ -1,0 +1,122 @@
+# Research Before Building
+
+This is the Antigravity adapter for the shared `Research` workflow in `core/workflows/research.md`. Keep shared workflow behavior aligned there; this file exists to preserve Antigravity-specific `/pdd-*` command wording.
+
+## Purpose
+
+Explore the problem space before implementation so the team can adopt, extend, compose, or build with intention.
+
+Research exists to prevent waste. Do not jump straight from "I want feature X" to implementation prompts when the real question is still "what problem are we solving, and what already exists?"
+
+## Use When
+
+- The user is unsure which approach to take.
+- Existing tools or libraries may already solve the problem.
+- The feature is expensive or risky enough to justify pre-work.
+- The team needs a build-vs-adopt decision with explicit tradeoffs.
+
+## Inputs
+
+- Problem statement
+- constraints
+- success criteria
+- any candidate tools or approaches already under consideration
+
+## Step 1: Clarify The Problem
+
+Ask conversationally:
+
+- What problem are you trying to solve?
+- Who encounters this problem and when?
+- What happens today without this?
+- What does success look like?
+
+If the user already has a clear, narrow need, skip most of the discovery and move directly to scanning for solutions.
+
+## Step 2: Surface Constraints
+
+Capture the constraints that shape the decision:
+
+- performance or scale requirements
+- security, privacy, or compliance requirements
+- integration points with the existing codebase
+- timeline or effort budget
+- things that are explicitly out of scope
+
+These notes should be reusable later in `/pdd-plan`, `/pdd-prompts`, and `/pdd-review`.
+
+## Step 3: Scan For Existing Solutions
+
+Check these sources in order:
+
+1. Existing codebase
+2. Prompt history and templates
+3. Package or tool ecosystem
+4. MCP servers or external capabilities
+5. Framework built-ins
+
+Look for solutions that are current, maintained, and compatible with the project constraints.
+
+## Step 4: Evaluate The Approaches
+
+Use these four buckets:
+
+| Approach | When to use | Example |
+|---|---|---|
+| **Adopt** | An existing tool already fits | Use zod for validation |
+| **Extend** | Something close exists but needs small customization | Fork a template, add constraints |
+| **Compose** | Several existing pieces fit together well | Wrap two tools behind one local interface |
+| **Build** | Nothing fits, or constraints rule out the existing options | Implement a custom solution |
+
+Present findings in a durable format:
+
+```markdown
+## Research: <problem being solved>
+
+### Problem
+<1-2 sentence problem statement>
+
+### Key constraints
+- <constraint>
+
+### Options evaluated
+#### Option 1: <name> (Adopt / Extend / Compose / Build)
+**What**: ...
+**Pros**: ...
+**Cons**: ...
+**Effort**: Low | Medium | High
+
+### Recommendation
+<which approach and why>
+```
+
+## Produces
+
+- an option set
+- tradeoff analysis
+- a recommendation
+- explicit reasoning for build vs adopt decisions
+- reusable notes for later workflows
+
+## Step 5: Decide And Proceed
+
+- **Adopt**: help install, configure, or integrate it
+- **Extend**: move to `/pdd-prompts` with adaptation guidance
+- **Compose**: move to `/pdd-plan` or `/pdd-prompts` depending on complexity
+- **Build**: move to `/pdd-plan` for multi-step work, or `/pdd-prompts` if the task is still small and clear
+
+Record the decision and rejected alternatives in `pdd/context/decisions.md`.
+
+If the findings will matter later, save the full summary in `pdd/context/research/<topic>.md`.
+
+## Edge Cases
+
+- **User already knows what to build**: skip most discovery and do a fast solution scan
+- **User wants to build anyway**: respect the choice, but log the rejected alternatives
+- **Multiple good options**: present the comparison clearly and let the user decide
+- **No existing solutions**: confirm the scan was thorough, then proceed to `/pdd-plan`
+- **Problem is too vague**: narrow it to one use case or user story before researching broadly
+
+## Default Next Step
+
+If the recommendation is to build, move to `/pdd-plan`. If the research settles a small change directly, move to `/pdd-prompts`.

--- a/providers/antigravity/workflows/pdd-review.md
+++ b/providers/antigravity/workflows/pdd-review.md
@@ -1,0 +1,106 @@
+# Review AI-Generated Output
+
+This is the Antigravity adapter for the shared `Review` workflow in `core/workflows/review.md`. Keep shared workflow behavior aligned there; this file exists to preserve Antigravity-specific `/pdd-*` command wording.
+
+## Purpose
+
+Treat AI-generated output like a PR by verifying correctness, identifying regressions, and calling out missing tests or checks.
+
+Review should combine objective verification with judgment. The goal is not just "does it run?" but "is this safe, understandable, and worth committing?"
+
+## Use When
+
+- The AI generated code, docs, config, or another artifact that may be committed.
+- The user asks if something is ready to commit.
+- The team needs a quick risk assessment before merging or shipping.
+
+## Inputs
+
+- generated output
+- relevant files or diffs
+- expected behavior
+
+## Before Reviewing
+
+- Read `pdd/context/project.md` if it exists for project standards and stack context.
+- Read `pdd/context/conventions.md` if it exists for style and architectural rules.
+- If no context exists, ask what the output was supposed to do and note that future reviews will be stronger with context files.
+
+If the user pastes code without explaining the goal, ask what they prompted and what they expected.
+
+Load the matching project-type reference file to apply the right checklist for that domain.
+
+## Phase 1: Verification
+
+Run the relevant checks in order. Skip checks that do not apply to the project.
+
+| Check | What it checks |
+|---|---|
+| **Build** | Code compiles or builds without errors |
+| **Type check** | Static type checks pass, if applicable |
+| **Lint** | No new lint violations |
+| **Test** | Existing tests pass and new code has adequate coverage |
+| **Security** | No hardcoded secrets, obvious injection risks, or dependency red flags |
+
+If a verification step fails, surface it clearly before spending time on lower-priority polish.
+
+## Phase 2: Subjective Review
+
+Evaluate the output from four angles:
+
+### 1. Correctness
+
+Does it do what was requested? Are there obvious bugs, broken flows, or missing edge-case handling?
+
+### 2. Project Fit
+
+Does it match the documented stack, conventions, and prior decisions?
+
+### 3. Maintainability
+
+Will a teammate understand this later? Is the structure clear? Are there anti-patterns or unnecessary complexity?
+
+### 4. Prompt Signal
+
+What does this output say about the prompt quality? Should the next fix happen in code, in the prompt, or both?
+
+Then apply the project-type review checklist from the relevant reference file.
+
+## Issue Severity
+
+Tag findings with a severity level:
+
+| Severity | Meaning | Action |
+|---|---|---|
+| **Blocking** | Broken, insecure, or violates a hard constraint | Must fix before committing |
+| **Should fix** | Missing edge case, wrong pattern, or convention violation | Fix before or soon after committing |
+| **Consider** | Optional improvement or low-risk polish | Fix if time allows |
+
+## Produces
+
+- review findings
+- verification results
+- fix guidance or a commit-ready recommendation
+
+## Output Format
+
+Structure the review like this:
+
+1. **Verification** — pass/fail per relevant check
+2. **What's good** — specific strengths
+3. **Issues** — ordered by severity, highest risk first
+4. **Suggestions** — optional improvements
+5. **Prompt feedback** — how to improve the prompt that generated the output
+6. **Next step** — one clear action
+
+## Edge Cases
+
+- **Mostly good**: say so clearly and recommend commit after any small fixes
+- **Fundamentally wrong**: name the root cause and route to `/pdd-update`
+- **Very large output**: focus on the highest-risk areas and explicitly note what was not reviewed
+- **User disagrees**: explain once, stay concrete, and let them decide
+- **First review of a new prompt**: suggest capturing an eval checklist in `pdd/evals/`
+
+## Default Next Step
+
+If issues are found, iterate on code or prompts. If the output is solid, commit it and consider `/pdd-eval`.

--- a/providers/antigravity/workflows/pdd-scaffold.md
+++ b/providers/antigravity/workflows/pdd-scaffold.md
@@ -1,0 +1,100 @@
+# Scaffold a PDD Project
+
+This is the Antigravity adapter for the shared `Scaffold` workflow in `core/workflows/scaffold.md`. Keep shared workflow behavior aligned there; this file exists to preserve Antigravity-specific `/pdd-*` command wording.
+
+## Purpose
+
+Set up a brand new PDD project structure for a project that does not have an established repo layout yet.
+
+Scaffold is for true greenfield work. It creates the PDD structure, establishes the default source layout, and prepares the repo for the first `/pdd-context` pass.
+
+## Use When
+
+- The user is starting from scratch.
+- They want folders, starter context stubs, and a clean workflow entrypoint.
+- There is no established repository structure to preserve.
+
+## Inputs
+
+- Project name if one is available.
+- High-level project type or stack, if already known.
+
+## Step 1: Gather The Setup Inputs
+
+Confirm:
+
+- project name
+- source directory name, defaulting to `src/`
+- high-level project type if already known
+
+If the user already has a populated project directory or repository, route them to `/pdd-init` instead.
+
+## Step 2: Create The Base Structure
+
+Create every folder and file shown in this layout. The source directory defaults to `src/` unless the user chose a different source directory name in Step 1.
+
+```text
+<project-name>/
+  pdd/
+    prompts/
+      features/
+      templates/
+      experiments/
+    context/
+      project.md
+      conventions.md
+      decisions.md
+    evals/
+      baselines/
+      scripts/
+  <source-dir>/
+  README.md
+```
+
+On macOS/Linux, use commands like:
+
+```bash
+mkdir -p pdd/{prompts/{features,templates,experiments},context,evals/{baselines,scripts}} src
+touch pdd/context/project.md pdd/context/conventions.md pdd/context/decisions.md README.md
+```
+
+If the user chose a source directory name other than `src/`, replace `src` in the command with that name.
+
+Initialize git only if the directory is not already a repository.
+
+Adapt shell commands to the user's platform when needed.
+
+## Step 3: Explain The Structure
+
+Make it clear what each major folder is for:
+
+- `pdd/prompts/features/` for stable feature prompts
+- `pdd/prompts/templates/` for reusable patterns
+- `pdd/prompts/experiments/` for time-boxed exploratory prompts
+- `pdd/context/` for durable project context
+- source directory for reviewed output and hand-written code
+- `pdd/evals/` for prompt-quality checks
+
+## Step 4: Guardrails
+
+- do not overwrite existing files silently
+- if `pdd/context/project.md` already exists, stop and confirm before replacing anything
+- if the user already has a repo or meaningful source structure, prefer `/pdd-init`
+
+## Produces
+
+- PDD folder structure under `pdd/`
+- source directory, defaulting to `src/`
+- starter context files
+- project `README.md`
+- a natural handoff to the context workflow
+
+## Edge Cases
+
+- **User already has a repo**: route to `/pdd-init`
+- **User wants a non-`src` source dir**: honor it consistently
+- **User is unsure about project type**: scaffold first and refine during `/pdd-context`
+
+## Default Next Step
+
+Move to `/pdd-context` and fill in `pdd/context/project.md`, `conventions.md`, and `decisions.md`.

--- a/providers/antigravity/workflows/pdd-status.md
+++ b/providers/antigravity/workflows/pdd-status.md
@@ -1,0 +1,70 @@
+# PDD Project Status
+
+Check the health and completeness of the current PDD project setup.
+
+## What to check
+
+Scan the current project directory and report on each layer:
+
+<!-- GENERATED:antigravity-status-checks:start -->
+### 1. Context layer
+
+| Check | How |
+|---|---|
+| `pdd/context/project.md` exists and is non-empty | Read file, check for filled-in sections |
+| `pdd/context/conventions.md` exists and is non-empty | Read file |
+| `pdd/context/decisions.md` exists and has entries | Read file, count decisions |
+| Context is fresh | Check for `**Last updated**` dates; flag if older than 30 days |
+
+### 2. Prompts layer
+
+| Check | How |
+|---|---|
+| `pdd/prompts/features/` has prompt files | Glob for `pdd/prompts/features/**/*.md` |
+| Prompts follow the template structure | Spot-check for `## Task`, `## Context`, `## Constraints` sections |
+| `pdd/prompts/experiments/` has stale entries | Flag any experiment files older than 7 days; suggest "Promote to `pdd/prompts/features/` or delete" |
+| Prompt chains are complete | Check numbered sequences for gaps (for example, `-01-` exists but `-02-` is missing) |
+| Templates available | Check `pdd/prompts/templates/` for `.template.md` files. If empty but 3 or more feature prompts exist with similar structure, suggest extracting a template. |
+
+### 3. Evals layer
+
+| Check | How |
+|---|---|
+| `pdd/evals/` has eval files | Glob for `pdd/evals/*.md` |
+| Eval coverage | Compare prompts in `pdd/prompts/features/` vs evals; flag prompts without evals |
+
+### 4. Output layer
+
+| Check | How |
+|---|---|
+| `src/` has committed artifacts | Check if `src/` has files |
+| Uncommitted AI output | Check git status for untracked files outside the PDD structure |
+<!-- GENERATED:antigravity-status-checks:end -->
+
+## Output format
+
+<!-- GENERATED:antigravity-status-output-format:start -->
+```text
+## PDD Status: <project name>
+
+### Context  [OK / NEEDS ATTENTION]
+- project.md: <status>
+- conventions.md: <status>
+- decisions.md: <status>
+
+### Prompts  [OK / NEEDS ATTENTION]
+- Feature prompts: <count> across <areas count> areas
+- Experiments: <count> (<stale count> stale)
+- Chains: <complete/incomplete>
+
+### Evals  [OK / NEEDS ATTENTION]
+- Eval files: <count>
+- Coverage: <prompts with evals> / <total prompts>
+
+### Suggestions
+- <actionable next step>
+- <actionable next step>
+```
+
+Keep the output concise. Only flag problems and suggest the single most impactful next action.
+<!-- GENERATED:antigravity-status-output-format:end -->

--- a/providers/antigravity/workflows/pdd-update.md
+++ b/providers/antigravity/workflows/pdd-update.md
@@ -1,0 +1,83 @@
+# Update an Existing Prompt
+
+This is the Antigravity adapter for the shared `Update` workflow in `core/workflows/update.md`. Keep shared workflow behavior aligned there; this file exists to preserve Antigravity-specific `/pdd-*` command wording.
+
+## Purpose
+
+Improve a prompt that is underperforming instead of immediately rewriting it from scratch.
+
+Default to diagnosis before replacement. Most weak prompts need a few targeted fixes, not a full rewrite.
+
+## Use When
+
+- The prompt produces wrong output.
+- The results are inconsistent, incomplete, or too broad.
+- The user can describe what went wrong.
+- The prompt worked once but is no longer reliable enough to trust.
+
+## Inputs
+
+- the existing prompt
+- observed failure mode
+- desired behavior
+
+## Step 1: Identify The Root Cause
+
+Ask for the prompt and the resulting output if they are not already available.
+
+Use this symptom table to guide the diagnosis:
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Output is too generic | Missing context | Add project or tech context |
+| Output ignores constraints | Constraints are vague or buried | Move constraints higher and make them explicit |
+| Output does too many things | Task is too broad | Split into multiple prompts |
+| Output format is wrong | Format is underspecified | Add an explicit output format section |
+| Output drifts across runs | Prompt is ambiguous | Add concrete examples or tighter language |
+| Output contradicts conventions | No conventions reference | Pull in `pdd/context/conventions.md` |
+
+If possible, run the prompt 2 to 3 times:
+
+- **Consistent errors** usually mean the prompt is wrong
+- **Inconsistent output** usually means the prompt is ambiguous
+- **Correct but unusable output** usually means the format or scope is wrong
+
+## Step 2: Apply Targeted Fixes
+
+Prefer the smallest effective change:
+
+- add missing context
+- elevate buried constraints
+- add a concrete example
+- narrow the task
+- split one overloaded prompt into smaller prompts
+
+Only recommend a full rewrite when more than half the prompt needs to change.
+
+## Step 3: Show What Changed
+
+Do not just hand back a replacement prompt. Explain what changed and why.
+
+Where possible, show a before/after diff of the key sections so the user can learn from the change.
+
+## Produces
+
+- a revised prompt
+- clearer scope or constraints
+- a recommendation for how to re-run and verify it
+
+## Step 4: Verify And Version
+
+- suggest re-running the updated prompt 2 to 3 times
+- recommend reviewing the new output with `/pdd-review`
+- keep version history clear so the team knows what was fixed
+
+If the old prompt is effectively abandoned, move it to `pdd/prompts/experiments/` with a date prefix instead of silently losing that history.
+
+## When To Start Fresh
+
+Start from scratch only when the prompt is fundamentally the wrong shape for the job. In that case, route back to `/pdd-prompts` and preserve the old prompt as an experiment or historical reference.
+
+## Default Next Step
+
+Re-run the prompt, then move to `/pdd-review` on the resulting output.

--- a/providers/claude/commands/pdd-help.md
+++ b/providers/claude/commands/pdd-help.md
@@ -1,6 +1,6 @@
 # PDD Help
 
-> **Version**: v1.5.0
+> **Version**: v1.4.0-3-gf83deb4
 
 Quick reference for all PDD commands, workflow order, and usage guidance.
 

--- a/scripts/render_workflow_tables.py
+++ b/scripts/render_workflow_tables.py
@@ -46,6 +46,7 @@ WORKFLOW_RENDER_IDS = (
 TARGET_SPECS = {
     "README.md": (
         "claude-command-table",
+        "antigravity-command-table",
     ),
     "providers/copilot/README.md": (
         "copilot-command-table",
@@ -108,6 +109,39 @@ TARGET_SPECS = {
     "providers/copilot/prompts/pdd-update.prompt.md": (),
     "providers/copilot/prompts/pdd-review.prompt.md": (),
     "providers/copilot/prompts/pdd-eval.prompt.md": (),
+    "providers/antigravity/README.md": (
+        "antigravity-command-table",
+    ),
+    "providers/antigravity/GEMINI.md": (
+        "antigravity-principles",
+        "antigravity-routing-table",
+    ),
+    "providers/antigravity/skills/pdd/SKILL.md": (
+        "antigravity-workflow-overview",
+        "antigravity-workflow-transitions",
+        "antigravity-quick-path",
+        "antigravity-principles",
+        "antigravity-routing-table",
+    ),
+    "providers/antigravity/workflows/pdd-help.md": (
+        "antigravity-help-quick-start",
+        "antigravity-help-command-groups",
+        "antigravity-help-scenarios",
+        "antigravity-help-command-detail",
+    ),
+    "providers/antigravity/workflows/pdd-status.md": (
+        "antigravity-status-checks",
+        "antigravity-status-output-format",
+    ),
+    "providers/antigravity/workflows/pdd-scaffold.md": (),
+    "providers/antigravity/workflows/pdd-init.md": (),
+    "providers/antigravity/workflows/pdd-context.md": (),
+    "providers/antigravity/workflows/pdd-research.md": (),
+    "providers/antigravity/workflows/pdd-plan.md": (),
+    "providers/antigravity/workflows/pdd-prompts.md": (),
+    "providers/antigravity/workflows/pdd-update.md": (),
+    "providers/antigravity/workflows/pdd-review.md": (),
+    "providers/antigravity/workflows/pdd-eval.md": (),
 }
 INLINE_CODE_RE = re.compile(r"`([^`\n]+)`")
 
@@ -292,6 +326,21 @@ def render_help_document(workflows, help_meta, provider_id):
             "scenarios": "copilot-help-scenarios",
             "command_detail": "copilot-help-command-detail",
         }
+    elif provider_id == "antigravity":
+        frontmatter = ""
+        user_input = ""
+        specific_heading = "## If the user asked about a specific command"
+        specific_text = (
+            'If the user mentioned a specific command (e.g., "context", "pdd-context", "review"), '
+            "show detailed help for that command only:"
+        )
+        fallback_heading = "## If no specific command was mentioned"
+        markers = {
+            "quick_start": "antigravity-help-quick-start",
+            "command_groups": "antigravity-help-command-groups",
+            "scenarios": "antigravity-help-scenarios",
+            "command_detail": "antigravity-help-command-detail",
+        }
     else:
         raise ValueError(f"Unsupported help provider_id: {provider_id}")
 
@@ -369,6 +418,13 @@ def render_status_document(status_meta, provider_id):
             "checks": "copilot-status-checks",
             "output": "copilot-status-output-format",
         }
+    elif provider_id == "antigravity":
+        frontmatter = ""
+        user_input = ""
+        markers = {
+            "checks": "antigravity-status-checks",
+            "output": "antigravity-status-output-format",
+        }
     else:
         raise ValueError(f"Unsupported status provider_id: {provider_id}")
 
@@ -395,6 +451,7 @@ def render_routing_table(workflows, routing_meta, provider_id):
         "claude": ("If the user says...", "Use workflow"),
         "copilot": ("User intent", "Suggest"),
         "codex": ("If the user wants to...", "Use"),
+        "antigravity": ("User intent", "Use"),
     }
     rows = []
     for route in routing_meta["routes"]:
@@ -408,6 +465,9 @@ def render_routing_table(workflows, routing_meta, provider_id):
         elif provider_id == "codex":
             left = route["codex_intent"]
             right = f"`{workflow['providers']['codex']}`"
+        elif provider_id == "antigravity":
+            left = route["antigravity_intent"]
+            right = f"Use `{workflow['providers']['antigravity']}`"
         else:
             raise ValueError(f"Unsupported provider_id: {provider_id}")
         rows.append((left, right))
@@ -500,6 +560,18 @@ def render_workflow_adapter_document(workflow, adapter_meta, workflows, provider
             f"{body}\n"
         )
 
+    if provider_id == "antigravity":
+        adapter_note = (
+            f"This is the Antigravity adapter for the shared `{workflow['label']}` workflow in "
+            f"`core/workflows/{workflow['id']}.md`. Keep shared workflow behavior aligned there; "
+            "this file exists to preserve Antigravity-specific `/pdd-*` command wording."
+        )
+        return (
+            f"# {title}\n\n"
+            f"{adapter_note}\n\n"
+            f"{body}\n"
+        )
+
     raise ValueError(f"Unsupported workflow adapter provider_id: {provider_id}")
 
 
@@ -531,6 +603,7 @@ def render_files():
     rendered_blocks = {
         ROOT / "README.md": {
             "claude-command-table": markdown_table(provider_rows(workflows, "claude")),
+            "antigravity-command-table": markdown_table(provider_rows(workflows, "antigravity")),
         },
         ROOT / "providers/copilot/README.md": {
             "copilot-command-table": markdown_table(provider_rows(workflows, "copilot")),
@@ -555,12 +628,28 @@ def render_files():
             "codex-complex-flow": principles_meta["codex_default_flow"]["complex"],
             "codex-routing-table": render_routing_table(workflows, routing_meta, "codex"),
         },
+        ROOT / "providers/antigravity/README.md": {
+            "antigravity-command-table": markdown_table(provider_rows(workflows, "antigravity")),
+        },
+        ROOT / "providers/antigravity/GEMINI.md": {
+            "antigravity-principles": render_principles(principles_meta, "antigravity"),
+            "antigravity-routing-table": render_routing_table(workflows, routing_meta, "antigravity"),
+        },
+        ROOT / "providers/antigravity/skills/pdd/SKILL.md": {
+            "antigravity-workflow-overview": render_claude_workflow_overview(workflows, claude_skill_meta),
+            "antigravity-workflow-transitions": render_claude_transitions(claude_skill_meta),
+            "antigravity-quick-path": f"**Quick path**: {principles_meta['claude_quick_path']}",
+            "antigravity-principles": render_principles(principles_meta, "antigravity"),
+            "antigravity-routing-table": render_routing_table(workflows, routing_meta, "antigravity"),
+        },
     }
     fully_rendered_targets = {
         ROOT / "providers/claude/commands/pdd-help.md": render_help_document(workflows, help_meta, "claude"),
         ROOT / "providers/copilot/prompts/pdd-help.prompt.md": render_help_document(workflows, help_meta, "copilot"),
+        ROOT / "providers/antigravity/workflows/pdd-help.md": render_help_document(workflows, help_meta, "antigravity"),
         ROOT / "providers/claude/commands/pdd-status.md": render_status_document(status_meta, "claude"),
         ROOT / "providers/copilot/prompts/pdd-status.prompt.md": render_status_document(status_meta, "copilot"),
+        ROOT / "providers/antigravity/workflows/pdd-status.md": render_status_document(status_meta, "antigravity"),
     }
     for workflow_id in WORKFLOW_RENDER_IDS:
         workflow = workflow_map[workflow_id]
@@ -571,6 +660,9 @@ def render_files():
         fully_rendered_targets[
             ROOT / f"providers/copilot/prompts/pdd-{workflow_id}.prompt.md"
         ] = render_workflow_adapter_document(workflow, adapter_meta, workflows, "copilot")
+        fully_rendered_targets[
+            ROOT / f"providers/antigravity/workflows/pdd-{workflow_id}.md"
+        ] = render_workflow_adapter_document(workflow, adapter_meta, workflows, "antigravity")
 
     expected_paths = set(target_paths())
     actual_paths = set(rendered_blocks) | set(fully_rendered_targets)

--- a/scripts/verify_structure.py
+++ b/scripts/verify_structure.py
@@ -63,6 +63,10 @@ def main() -> None:
             ROOT / f"providers/copilot/prompts/pdd-{workflow_id}.prompt.md",
             f"providers/copilot/prompts/pdd-{workflow_id}.prompt.md exists",
         )
+        assert_file(
+            ROOT / f"providers/antigravity/workflows/pdd-{workflow_id}.md",
+            f"providers/antigravity/workflows/pdd-{workflow_id}.md exists",
+        )
 
     for ref in sorted((ROOT / "core/references").glob("*.md")):
         ok(f"{ref.relative_to(ROOT)} exists")
@@ -91,6 +95,18 @@ def main() -> None:
         ROOT / ".agents/plugins/marketplace.json",
         ".agents/plugins/marketplace.json exists",
     )
+    assert_file(
+        ROOT / "providers/antigravity/GEMINI.md",
+        "providers/antigravity/GEMINI.md exists",
+    )
+    assert_file(
+        ROOT / "providers/antigravity/skills/pdd/SKILL.md",
+        "providers/antigravity/skills/pdd/SKILL.md exists",
+    )
+    assert_file(
+        ROOT / "providers/antigravity/README.md",
+        "providers/antigravity/README.md exists",
+    )
 
     assert_symlink(ROOT / ".claude-plugin", "providers/claude/plugin")
     assert_symlink(ROOT / "plugins/pdd-skill", "../providers/codex/plugin")
@@ -103,12 +119,13 @@ def main() -> None:
         ok(f"{removed} removed (no longer a compatibility symlink)")
 
     provider_ids = {provider["id"] for provider in provider_meta}
-    if provider_ids != {"claude", "copilot", "codex"}:
+    expected_provider_ids = {"claude", "copilot", "codex", "antigravity"}
+    if provider_ids != expected_provider_ids:
         fail(f"provider ids mismatch: {sorted(provider_ids)}")
-    ok("provider metadata covers claude, copilot, and codex")
+    ok("provider metadata covers claude, copilot, codex, and antigravity")
 
     readme = (ROOT / "README.md").read_text()
-    for expected in ("Claude Code", "GitHub Copilot", "Codex", "core/", "providers/"):
+    for expected in ("Claude Code", "GitHub Copilot", "Codex", "Antigravity", "core/", "providers/"):
         if expected not in readme:
             fail(f"README.md missing {expected!r}")
     ok("README.md covers the multi-provider structure")

--- a/tests/test_metadata_model.py
+++ b/tests/test_metadata_model.py
@@ -122,7 +122,7 @@ def validate_routing(workflow_ids):
     assert_equal(len(route_ids), len(set(route_ids)), "routing workflow ids are unique")
 
     for route in routing_meta["routes"]:
-        for key in ("claude_signal", "copilot_intent", "codex_intent"):
+        for key in ("claude_signal", "copilot_intent", "codex_intent", "antigravity_intent"):
             assert_true(bool(route[key].strip()), f"routing text present for {route['workflow_id']}.{key}")
 
 
@@ -152,7 +152,7 @@ def validate_status():
         assert_true(bool(layer["title"].strip()), f"status layer title is present: {layer['title']}")
         assert_true(bool(layer["checks"]), f"status layer has checks: {layer['title']}")
         for check in layer["checks"]:
-            for key in ("check", "claude_how", "copilot_how"):
+            for key in ("check", "claude_how", "copilot_how", "antigravity_how"):
                 assert_true(bool(check[key].strip()), f"status check has {key}: {layer['title']}")
 
     assert_true(bool(status_meta["output_format"]), "status output format is present")

--- a/tests/test_provider_packaging.py
+++ b/tests/test_provider_packaging.py
@@ -77,6 +77,34 @@ def test_copilot_copy_surface(repo_copy: pathlib.Path) -> None:
     assert_true(len(reference_files) == 16, "Copilot install gets all 16 reference files")
 
 
+def test_antigravity_copy_surface(repo_copy: pathlib.Path) -> None:
+    install_root = repo_copy / "_tmp-antigravity-project"
+    install_root.mkdir()
+
+    shutil.copy2(repo_copy / "providers/antigravity/GEMINI.md", install_root / "GEMINI.md")
+    skill_dir = install_root / ".agents/skills/pdd"
+    skill_dir.mkdir(parents=True)
+    shutil.copy2(repo_copy / "providers/antigravity/skills/pdd/SKILL.md", skill_dir / "SKILL.md")
+    shutil.copytree(repo_copy / "providers/antigravity/workflows", install_root / ".agent/workflows")
+    shutil.copytree(repo_copy / "core/references", install_root / ".agent/references")
+
+    assert_file(install_root / "GEMINI.md", "Antigravity copy surface installs GEMINI.md")
+    assert_file(skill_dir / "SKILL.md", "Antigravity copy surface installs skill entrypoint")
+    assert_file(
+        install_root / ".agent/workflows/pdd-context.md",
+        "Antigravity copy surface installs workflow files",
+    )
+    assert_file(
+        install_root / ".agent/references/frontend.md",
+        "Antigravity copy surface installs shared references",
+    )
+
+    workflow_files = sorted((install_root / ".agent/workflows").glob("*.md"))
+    reference_files = sorted((install_root / ".agent/references").glob("*.md"))
+    assert_true(len(workflow_files) == 11, "Antigravity install gets all 11 workflow files")
+    assert_true(len(reference_files) == 16, "Antigravity install gets all 16 reference files")
+
+
 def test_codex_plugin_surface(repo_copy: pathlib.Path) -> None:
     plugin_root = repo_copy / "plugins/pdd-skill"
     assert_true(plugin_root.is_dir(), "Codex compatibility plugin path resolves to a directory")
@@ -114,6 +142,7 @@ def main() -> None:
         test_claude_clone_surface(repo_copy)
         test_copilot_copy_surface(repo_copy)
         test_codex_plugin_surface(repo_copy)
+        test_antigravity_copy_surface(repo_copy)
         test_manifest_alignment(repo_copy)
 
 


### PR DESCRIPTION
## Summary
- Adds `providers/antigravity/` mirroring the Claude/Copilot adapter shape: skill entrypoint, `GEMINI.md` workspace rules, 11 workflow files, install README.
- Antigravity reads `.agents/skills/{name}/SKILL.md` (nearly identical to Claude's skill format) and auto-exposes `.agent/workflows/*.md` as `/`-prefixed slash commands, so the adapter is a directory rename of the existing patterns rather than a new extension model.
- Render script, structure verifier, metadata-model test, and packaging test extended to cover the new provider.

## Design decisions
- **`GEMINI.md` instead of `AGENTS.md`** — `AGENTS.md` is now a cross-tool standard (Cursor, Codex, Antigravity all read it). Using the Antigravity-specific filename avoids a collision when a repo installs both providers.
- **No plugin manifest** — Antigravity's plugin schema isn't publicly documented. Dropping skill files in is sufficient for v1.
- **No subagent definitions** — Antigravity subagents are orchestrator-spawned at runtime, not user-declarable. This is the one place Antigravity diverges from the other providers; out of scope for v1.
- **No `#file:` reference rewriting** — Antigravity has no documented `#file:` equivalent; references in workflow bodies stay as plain prose.

## Test plan
- [x] `python3 scripts/render_workflow_tables.py --check` — clean, no stale rendered content
- [x] `bash tests/consistency.sh` — all green (includes verify_structure, metadata model, provider packaging)
- [x] `bash tests/test-hooks.sh` — 10/10 pass (no regressions)
- [x] Install surfaces verified: new `test_antigravity_copy_surface` test confirms `GEMINI.md`, skill, 11 workflows, and 16 references all install cleanly into a temp project tree
- [ ] CI passes on the PR